### PR TITLE
Change components_ attribute in mv_ica to fit documentation

### DIFF
--- a/mvlearn/decomposition/mv_ica.py
+++ b/mvlearn/decomposition/mv_ica.py
@@ -131,11 +131,12 @@ class MultiviewICA(BaseICA):
     Attributes
     ----------
     components_ : np array of shape (n_groups, n_features, n_components)
-        P is the projection matrix that projects data in reduced space
+        The projection matrices that project group data in reduced space.
+        Only available if n_components is not None
     unmixings_ : np array of shape (n_groups, n_components, n_components)
         Estimated un-mixing matrices
     source_ : np array of shape (n_samples, n_components)
-        Estimated source
+        Estimated source matrix
 
     See also
     --------
@@ -283,11 +284,12 @@ class PermICA(BaseICA):
     Attributes
     ----------
     components_ : np array of shape (n_groups, n_features, n_components)
-        P is the projection matrix that projects data in reduced space
+        The projection matrices that project group data in reduced space.
+        Only available if n_components is not None
     unmixings_ : np array of shape (n_groups, n_components, n_components)
         Estimated un-mixing matrices
     source_ : np array of shape (n_samples, n_components)
-        Estimated source
+        Estimated source matrix
 
     See also
     --------
@@ -409,11 +411,12 @@ class GroupICA(BaseICA):
     Attributes
     ----------
     components_ : np array of shape (n_groups, n_features, n_components)
-        P is the projection matrix that projects data in reduced space
+        The projection matrices that project group data in reduced space.
+        Only available if n_components is not None
     unmixings_ : np array of shape (n_groups, n_components, n_components)
         Estimated un-mixing matrices
     source_ : np array of shape (n_samples, n_components)
-        Estimated source
+        Estimated source matrix
 
     See also
     --------
@@ -533,7 +536,7 @@ def _reduce_data(Xs, n_components, n_jobs=None):
         delayed(temp)(X) for X in Xs
     )
     projections, reduced = zip(*parallelized_pca)
-    return projections, np.asarray(reduced)
+    return np.asarray(projections), np.asarray(reduced)
 
 
 def _multiview_ica_main(

--- a/mvlearn/decomposition/mv_ica.py
+++ b/mvlearn/decomposition/mv_ica.py
@@ -132,7 +132,7 @@ class MultiviewICA(BaseICA):
     ----------
     components_ : np array of shape (n_groups, n_features, n_components)
         The projection matrices that project group data in reduced space.
-        Only available if n_components is not None
+        Has value None if n_components is None
     unmixings_ : np array of shape (n_groups, n_components, n_components)
         Estimated un-mixing matrices
     source_ : np array of shape (n_samples, n_components)
@@ -285,7 +285,7 @@ class PermICA(BaseICA):
     ----------
     components_ : np array of shape (n_groups, n_features, n_components)
         The projection matrices that project group data in reduced space.
-        Only available if n_components is not None
+        Has value None if n_components is None
     unmixings_ : np array of shape (n_groups, n_components, n_components)
         Estimated un-mixing matrices
     source_ : np array of shape (n_samples, n_components)
@@ -412,7 +412,7 @@ class GroupICA(BaseICA):
     ----------
     components_ : np array of shape (n_groups, n_features, n_components)
         The projection matrices that project group data in reduced space.
-        Only available if n_components is not None
+        Has value None if n_components is None
     unmixings_ : np array of shape (n_groups, n_components, n_components)
         Estimated un-mixing matrices
     source_ : np array of shape (n_samples, n_components)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/mvlearn/mvlearn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #215 

#### What does this implement/fix? Explain your changes.
Changes the components_ attribute to be a np.array, rather than a tuple, so that it matches the documentation's description. Also, add a line to the description of the components_ attribute to say it has the value None unless n_components was explicitly set to not be None.

#### Any other comments?

