### PR TITLE
Switch license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,202 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+The MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2020 The mvlearn developers.
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2020 Richard Guo, Ronan Perry, Gavin Mischler, Theo Lee,
-      Alexander Chang, Arman Koul, Cameron Franz
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,208 +1,27 @@
 License
 =======
-mvlearn is distributed with Apache 2.0 license.
+mvlearn is distributed with MIT license.
 
 ::
 
-    Apache License
-                            Version 2.0, January 2004
-                            http://www.apache.org/licenses/
+    The MIT License
 
-    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+    Copyright (c) 2020 The mvlearn developers.
 
-    1. Definitions.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
 
-        "License" shall mean the terms and conditions for use, reproduction,
-        and distribution as defined by Sections 1 through 9 of this document.
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
 
-        "Licensor" shall mean the copyright owner or entity authorized by
-        the copyright owner that is granting the License.
-
-        "Legal Entity" shall mean the union of the acting entity and all
-        other entities that control, are controlled by, or are under common
-        control with that entity. For the purposes of this definition,
-        "control" means (i) the power, direct or indirect, to cause the
-        direction or management of such entity, whether by contract or
-        otherwise, or (ii) ownership of fifty percent (50%) or more of the
-        outstanding shares, or (iii) beneficial ownership of such entity.
-
-        "You" (or "Your") shall mean an individual or Legal Entity
-        exercising permissions granted by this License.
-
-        "Source" form shall mean the preferred form for making modifications,
-        including but not limited to software source code, documentation
-        source, and configuration files.
-
-        "Object" form shall mean any form resulting from mechanical
-        transformation or translation of a Source form, including but
-        not limited to compiled object code, generated documentation,
-        and conversions to other media types.
-
-        "Work" shall mean the work of authorship, whether in Source or
-        Object form, made available under the License, as indicated by a
-        copyright notice that is included in or attached to the work
-        (an example is provided in the Appendix below).
-
-        "Derivative Works" shall mean any work, whether in Source or Object
-        form, that is based on (or derived from) the Work and for which the
-        editorial revisions, annotations, elaborations, or other modifications
-        represent, as a whole, an original work of authorship. For the purposes
-        of this License, Derivative Works shall not include works that remain
-        separable from, or merely link (or bind by name) to the interfaces of,
-        the Work and Derivative Works thereof.
-
-        "Contribution" shall mean any work of authorship, including
-        the original version of the Work and any modifications or additions
-        to that Work or Derivative Works thereof, that is intentionally
-        submitted to Licensor for inclusion in the Work by the copyright owner
-        or by an individual or Legal Entity authorized to submit on behalf of
-        the copyright owner. For the purposes of this definition, "submitted"
-        means any form of electronic, verbal, or written communication sent
-        to the Licensor or its representatives, including but not limited to
-        communication on electronic mailing lists, source code control systems,
-        and issue tracking systems that are managed by, or on behalf of, the
-        Licensor for the purpose of discussing and improving the Work, but
-        excluding communication that is conspicuously marked or otherwise
-        designated in writing by the copyright owner as "Not a Contribution."
-
-        "Contributor" shall mean Licensor and any individual or Legal Entity
-        on behalf of whom a Contribution has been received by Licensor and
-        subsequently incorporated within the Work.
-
-    2. Grant of Copyright License. Subject to the terms and conditions of
-        this License, each Contributor hereby grants to You a perpetual,
-        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-        copyright license to reproduce, prepare Derivative Works of,
-        publicly display, publicly perform, sublicense, and distribute the
-        Work and such Derivative Works in Source or Object form.
-
-    3. Grant of Patent License. Subject to the terms and conditions of
-        this License, each Contributor hereby grants to You a perpetual,
-        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-        (except as stated in this section) patent license to make, have made,
-        use, offer to sell, sell, import, and otherwise transfer the Work,
-        where such license applies only to those patent claims licensable
-        by such Contributor that are necessarily infringed by their
-        Contribution(s) alone or by combination of their Contribution(s)
-        with the Work to which such Contribution(s) was submitted. If You
-        institute patent litigation against any entity (including a
-        cross-claim or counterclaim in a lawsuit) alleging that the Work
-        or a Contribution incorporated within the Work constitutes direct
-        or contributory patent infringement, then any patent licenses
-        granted to You under this License for that Work shall terminate
-        as of the date such litigation is filed.
-
-    4. Redistribution. You may reproduce and distribute copies of the
-        Work or Derivative Works thereof in any medium, with or without
-        modifications, and in Source or Object form, provided that You
-        meet the following conditions:
-
-        (a) You must give any other recipients of the Work or
-            Derivative Works a copy of this License; and
-
-        (b) You must cause any modified files to carry prominent notices
-            stating that You changed the files; and
-
-        (c) You must retain, in the Source form of any Derivative Works
-            that You distribute, all copyright, patent, trademark, and
-            attribution notices from the Source form of the Work,
-            excluding those notices that do not pertain to any part of
-            the Derivative Works; and
-
-        (d) If the Work includes a "NOTICE" text file as part of its
-            distribution, then any Derivative Works that You distribute must
-            include a readable copy of the attribution notices contained
-            within such NOTICE file, excluding those notices that do not
-            pertain to any part of the Derivative Works, in at least one
-            of the following places: within a NOTICE text file distributed
-            as part of the Derivative Works; within the Source form or
-            documentation, if provided along with the Derivative Works; or,
-            within a display generated by the Derivative Works, if and
-            wherever such third-party notices normally appear. The contents
-            of the NOTICE file are for informational purposes only and
-            do not modify the License. You may add Your own attribution
-            notices within Derivative Works that You distribute, alongside
-            or as an addendum to the NOTICE text from the Work, provided
-            that such additional attribution notices cannot be construed
-            as modifying the License.
-
-        You may add Your own copyright statement to Your modifications and
-        may provide additional or different license terms and conditions
-        for use, reproduction, or distribution of Your modifications, or
-        for any such Derivative Works as a whole, provided Your use,
-        reproduction, and distribution of the Work otherwise complies with
-        the conditions stated in this License.
-
-    5. Submission of Contributions. Unless You explicitly state otherwise,
-        any Contribution intentionally submitted for inclusion in the Work
-        by You to the Licensor shall be under the terms and conditions of
-        this License, without any additional terms or conditions.
-        Notwithstanding the above, nothing herein shall supersede or modify
-        the terms of any separate license agreement you may have executed
-        with Licensor regarding such Contributions.
-
-    6. Trademarks. This License does not grant permission to use the trade
-        names, trademarks, service marks, or product names of the Licensor,
-        except as required for reasonable and customary use in describing the
-        origin of the Work and reproducing the content of the NOTICE file.
-
-    7. Disclaimer of Warranty. Unless required by applicable law or
-        agreed to in writing, Licensor provides the Work (and each
-        Contributor provides its Contributions) on an "AS IS" BASIS,
-        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-        implied, including, without limitation, any warranties or conditions
-        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-        PARTICULAR PURPOSE. You are solely responsible for determining the
-        appropriateness of using or redistributing the Work and assume any
-        risks associated with Your exercise of permissions under this License.
-
-    8. Limitation of Liability. In no event and under no legal theory,
-        whether in tort (including negligence), contract, or otherwise,
-        unless required by applicable law (such as deliberate and grossly
-        negligent acts) or agreed to in writing, shall any Contributor be
-        liable to You for damages, including any direct, indirect, special,
-        incidental, or consequential damages of any character arising as a
-        result of this License or out of the use or inability to use the
-        Work (including but not limited to damages for loss of goodwill,
-        work stoppage, computer failure or malfunction, or any and all
-        other commercial damages or losses), even if such Contributor
-        has been advised of the possibility of such damages.
-
-    9. Accepting Warranty or Additional Liability. While redistributing
-        the Work or Derivative Works thereof, You may choose to offer,
-        and charge a fee for, acceptance of support, warranty, indemnity,
-        or other liability obligations and/or rights consistent with this
-        License. However, in accepting such obligations, You may act only
-        on Your own behalf and on Your sole responsibility, not on behalf
-        of any other Contributor, and only if You agree to indemnify,
-        defend, and hold each Contributor harmless for any liability
-        incurred by, or claims asserted against, such Contributor by reason
-        of your accepting any such warranty or additional liability.
-
-    END OF TERMS AND CONDITIONS
-
-    APPENDIX: How to apply the Apache License to your work.
-
-        To apply the Apache License to your work, attach the following
-        boilerplate notice, with the fields enclosed by brackets "[]"
-        replaced with your own identifying information. (Don't include
-        the brackets!)  The text should be enclosed in the appropriate
-        comment syntax for the file format. We also recommend that a
-        file or class name and description of purpose be included on the
-        same "printed page" as the copyright notice for easier
-        identification within third-party archives.
-
-    Copyright 2020 Richard Guo, Ronan Perry, Gavin Mischler, Theo Lee,
-        Alexander Chang, Arman Koul, Cameron Franz
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/examples/cluster/mv_spherical_benchmark_validation_noinclude.py
+++ b/examples/cluster/mv_spherical_benchmark_validation_noinclude.py
@@ -13,6 +13,8 @@ of *mvlearn*.
 
 """
 
+# License: MIT
+
 import numpy as np
 from mvlearn.cluster.mv_spherical_kmeans import MultiviewSphericalKMeans
 from spherecluster import SphericalKMeans, sample_vMF

--- a/examples/cluster/mv_spherical_paper_validation_noinclude.py
+++ b/examples/cluster/mv_spherical_paper_validation_noinclude.py
@@ -12,6 +12,8 @@ IEEE International Conference on Data Mining, pp. 19–26)
 
 """
 
+# License: MIT
+
 from sklearn.datasets import fetch_20newsgroups
 from sklearn.feature_extraction.text import TfidfVectorizer
 import numpy as np

--- a/examples/cluster/plot_mv_coregularized_spectral_tutorial.py
+++ b/examples/cluster/plot_mv_coregularized_spectral_tutorial.py
@@ -14,6 +14,8 @@ input types.
 
 """
 
+# License: MIT
+
 import warnings
 import numpy as np
 from sklearn.cluster import SpectralClustering

--- a/examples/cluster/plot_mv_kmeans_tutorial.py
+++ b/examples/cluster/plot_mv_kmeans_tutorial.py
@@ -9,6 +9,8 @@ digits dataset.
 
 """
 
+# License: MIT
+
 from mvlearn.datasets import load_UCImultifeature
 from mvlearn.cluster import MultiviewKMeans
 from sklearn.cluster import KMeans

--- a/examples/cluster/plot_mv_kmeans_validation_complex.py
+++ b/examples/cluster/plot_mv_kmeans_validation_complex.py
@@ -20,6 +20,8 @@ information metric.
 
 """
 
+# License: MIT
+
 import warnings
 import numpy as np
 from scipy import special

--- a/examples/cluster/plot_mv_kmeans_validation_simulated.py
+++ b/examples/cluster/plot_mv_kmeans_validation_simulated.py
@@ -9,6 +9,8 @@ allow the multiview version of the algorithm to perform well.
 
 """
 
+# License: MIT
+
 import warnings
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/cluster/plot_mv_spectral_tutorial.py
+++ b/examples/cluster/plot_mv_spectral_tutorial.py
@@ -9,6 +9,8 @@ and the UCI multiview digits dataset.
 
 """
 
+# License: MIT
+
 import warnings
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/cluster/plot_mv_spectral_validation_complex.py
+++ b/examples/cluster/plot_mv_spectral_validation_complex.py
@@ -12,6 +12,8 @@ between the views conditioned on true class labels.
 
 """
 
+# License: MIT
+
 import numpy as np
 import scipy as scp
 from mvlearn.cluster.mv_spectral import MultiviewSpectralClustering

--- a/examples/cluster/plot_mv_spectral_validation_simulated.py
+++ b/examples/cluster/plot_mv_spectral_validation_simulated.py
@@ -10,6 +10,8 @@ advantages.
 
 """
 
+# License: MIT
+
 import numpy as np
 from mvlearn.cluster import MultiviewSpectralClustering
 from sklearn.cluster import SpectralClustering

--- a/examples/cluster/plot_mv_spherical_kmeans_tutorial.py
+++ b/examples/cluster/plot_mv_spherical_kmeans_tutorial.py
@@ -8,6 +8,7 @@ on 2 views of the UCI multiview digits dataset.
 
 """
 
+# License: MIT
 
 from mvlearn.datasets import load_UCImultifeature
 from mvlearn.cluster import MultiviewSphericalKMeans

--- a/examples/cluster/plot_mv_vs_singleview_spectral.py
+++ b/examples/cluster/plot_mv_vs_singleview_spectral.py
@@ -11,6 +11,7 @@ the analagous singleview methods.
 
 """
 
+# License: MIT
 
 from sklearn.cluster import SpectralClustering
 from sklearn.metrics import homogeneity_score

--- a/examples/datasets/plot_gaussianmixtures.py
+++ b/examples/datasets/plot_gaussianmixtures.py
@@ -8,6 +8,8 @@ mixtures and plot the views against each other using a crossviews plot.
 
 """
 
+# License: MIT
+
 import numpy as np
 from mvlearn.datasets import GaussianMixture
 from mvlearn.plotting import crossviews_plot

--- a/examples/datasets/plot_load_ucimultifeature.py
+++ b/examples/datasets/plot_load_ucimultifeature.py
@@ -16,6 +16,8 @@ Kybernetika, vol. 34, no. 4, 1998, 381-386
 
 """
 
+# License: MIT
+
 from mvlearn.datasets import load_UCImultifeature
 from mvlearn.plotting import quick_visualize
 

--- a/examples/decomposition/plot_ajive_tutorial.py
+++ b/examples/decomposition/plot_ajive_tutorial.py
@@ -8,8 +8,6 @@ written by:
 
 Author: Iain Carmichael
 
-License: MIT License
-
 [1] Lock, Eric F., et al. “Joint and Individual Variation Explained (JIVE)
 for Integrated Analysis of Multiple Data Types.” The Annals of Applied
 Statistics, vol. 7, no. 1, 2013, pp. 523–542., doi:10.1214/12-aoas597.
@@ -26,6 +24,8 @@ whose sum is the original data minus noise. This notebook will demonstrate the
 functionality of AJIVE and show some examples of the algorithm's usefulness.
 
 """
+
+# License: MIT
 
 import numpy as np
 from mvlearn.decomposition import AJIVE

--- a/examples/decomposition/plot_group_ica_tutorial.py
+++ b/examples/decomposition/plot_group_ica_tutorial.py
@@ -26,6 +26,8 @@ allows to extract signals that are comon across views.
 
 """
 
+# License: MIT
+
 import numpy as np
 import matplotlib.pyplot as plt
 from mvlearn.decomposition import GroupICA

--- a/examples/embed/plot_cca_comparison.py
+++ b/examples/embed/plot_cca_comparison.py
@@ -29,6 +29,8 @@ views.
 
 """
 
+# License: MIT
+
 from mvlearn.embed import KCCA, DCCA
 from mvlearn.datasets import GaussianMixture
 import numpy as np

--- a/examples/embed/plot_dcca_tutorial.py
+++ b/examples/embed/plot_dcca_tutorial.py
@@ -15,6 +15,7 @@ this information in a low dimensional embedding.
 
 """
 
+# License: MIT
 
 import numpy as np
 from mvlearn.embed import DCCA

--- a/examples/embed/plot_gcca_tutorial.py
+++ b/examples/embed/plot_gcca_tutorial.py
@@ -9,6 +9,8 @@ use 3 views from the UCI Multiple Features Dataset.
 
 """
 
+# License: MIT
+
 from mvlearn.datasets import load_UCImultifeature
 from mvlearn.embed import GCCA
 from mvlearn.plotting import crossviews_plot

--- a/examples/embed/plot_kcca_icd_tutorial.py
+++ b/examples/embed/plot_kcca_icd_tutorial.py
@@ -13,6 +13,7 @@ run-time from O(n^3) to O(nm^2).
 
 """
 
+# License: MIT
 
 import time
 import matplotlib.cbook

--- a/examples/embed/plot_kcca_tutorial.py
+++ b/examples/embed/plot_kcca_tutorial.py
@@ -26,6 +26,7 @@ performance. The only method as of now is 'kettenring-like'.
 
 """
 
+# License: MIT
 
 import numpy as np
 from mvlearn.embed import KCCA

--- a/examples/embed/plot_mvmds_tutorial.py
+++ b/examples/embed/plot_mvmds_tutorial.py
@@ -9,6 +9,8 @@ time.
 
 """
 
+# License: MIT
+
 from mvlearn.datasets import load_UCImultifeature
 from mvlearn.embed import MVMDS
 import seaborn as sns

--- a/examples/embed/plot_omnibus_embedding.py
+++ b/examples/embed/plot_omnibus_embedding.py
@@ -30,6 +30,8 @@ different views in the UCI handwritten digits dataset.
 
 """
 
+# License: MIT
+
 from mvlearn.datasets.base import load_UCImultifeature
 import numpy as np
 from matplotlib import pyplot as plt

--- a/examples/embed/splitae_tutorial_noinclude.py
+++ b/examples/embed/splitae_tutorial_noinclude.py
@@ -10,6 +10,8 @@ to learn a latent embedding of the data.
 
 """
 
+# License: MIT
+
 import torch
 import torchvision
 from torch.utils.data import Dataset, DataLoader

--- a/examples/pipeline/plot_pipeline_sklearn_integration.py
+++ b/examples/pipeline/plot_pipeline_sklearn_integration.py
@@ -10,7 +10,9 @@ which are themselves 2d arrays of shape `(n_samples, n_features_i)`. The
 number of features does not have to be constant:
 
 """
+
 # Author: Pierre Ablin
+# License: MIT
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/plotting/plot_crossviews_plot.py
+++ b/examples/plotting/plot_crossviews_plot.py
@@ -11,6 +11,8 @@ simulated from transformations of multi-variant gaussians.
 
 """
 
+# License: MIT
+
 from mvlearn.datasets import GaussianMixture
 from mvlearn.plotting import crossviews_plot
 import numpy as np

--- a/examples/plotting/plot_quick_visualize_tutorial.py
+++ b/examples/plotting/plot_quick_visualize_tutorial.py
@@ -13,6 +13,8 @@ views of varying dimensionality.
 
 """
 
+# License: MIT
+
 from mvlearn.plotting import quick_visualize
 from mvlearn.datasets import load_UCImultifeature
 

--- a/examples/semi_supervised/cotraining_classification_simulatedperformance_noinclude.py
+++ b/examples/semi_supervised/cotraining_classification_simulatedperformance_noinclude.py
@@ -16,6 +16,8 @@ Specifically, we explore multiview vs. singleview classifier performance:
 - as labeled data proportion (labeld sample size) is varied
 """
 
+# License: MIT
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib

--- a/examples/semi_supervised/plot_cotraining_classification.py
+++ b/examples/semi_supervised/plot_cotraining_classification.py
@@ -10,6 +10,8 @@ and we do much better than using single-view methods trained on only the
 labeled samples.
 """
 
+# License: MIT
+
 import numpy as np
 from sklearn.naive_bayes import GaussianNB
 from sklearn.model_selection import train_test_split

--- a/examples/semi_supervised/plot_cotraining_regression.py
+++ b/examples/semi_supervised/plot_cotraining_regression.py
@@ -17,6 +17,8 @@ shows that the CTRegressor does better than using either KNeighborsRegressor
 alone in this semi-supervised case.
 """
 
+# License: MIT
+
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D

--- a/mvlearn/cluster/base.py
+++ b/mvlearn/cluster/base.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from abc import abstractmethod
 from sklearn.base import BaseEstimator

--- a/mvlearn/cluster/mv_coreg_spectral.py
+++ b/mvlearn/cluster/mv_coreg_spectral.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Implements multi-view spectral clustering algorithm for data with
 # multiple views.

--- a/mvlearn/cluster/mv_kmeans.py
+++ b/mvlearn/cluster/mv_kmeans.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Implements multi-view kmeans clustering algorithm for data with 2-views.
 

--- a/mvlearn/cluster/mv_spectral.py
+++ b/mvlearn/cluster/mv_spectral.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Implements multi-view spectral clustering algorithm for data with
 # multiple views.

--- a/mvlearn/cluster/mv_spherical_kmeans.py
+++ b/mvlearn/cluster/mv_spherical_kmeans.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Implements multi-view kmeans clustering algorithm for data with 2-views.
 

--- a/mvlearn/compose/merge.py
+++ b/mvlearn/compose/merge.py
@@ -1,18 +1,8 @@
 """Merging utilities."""
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 # Authors: Pierre Ablin
+#
+# License: MIT
 
 import numpy as np
 

--- a/mvlearn/compose/split.py
+++ b/mvlearn/compose/split.py
@@ -1,18 +1,8 @@
 """Splitting utilities."""
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 # Authors: Pierre Ablin
+#
+# License: MIT
 
 import numpy as np
 

--- a/mvlearn/construct/random_gaussian_projection.py
+++ b/mvlearn/construct/random_gaussian_projection.py
@@ -1,16 +1,6 @@
 # Copyright 2019 NeuroData (http://neurodata.io)
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 import numpy as np
 from sklearn.random_projection import GaussianRandomProjection

--- a/mvlearn/construct/rsm.py
+++ b/mvlearn/construct/rsm.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 import numpy as np
 import random

--- a/mvlearn/construct/utils.py
+++ b/mvlearn/construct/utils.py
@@ -1,17 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# License: MIT
 
 def check_n_views(n_views):
     """

--- a/mvlearn/datasets/base.py
+++ b/mvlearn/datasets/base.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from os.path import dirname, join
 import numpy as np

--- a/mvlearn/datasets/gaussian_mixture.py
+++ b/mvlearn/datasets/gaussian_mixture.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 import numpy as np
 from scipy.stats import ortho_group

--- a/mvlearn/decomposition/base.py
+++ b/mvlearn/decomposition/base.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from abc import abstractmethod
 

--- a/mvlearn/decomposition/groupica.py
+++ b/mvlearn/decomposition/groupica.py
@@ -1,18 +1,8 @@
 """Group Independent Component Analysis."""
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 # Authors: Pierre Ablin, Hugo Richard
+#
+# License: MIT
 
 import numpy as np
 from scipy import linalg

--- a/mvlearn/decomposition/grouppca.py
+++ b/mvlearn/decomposition/grouppca.py
@@ -1,18 +1,8 @@
 """Group Principal Component Analysis."""
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 # Authors: Pierre Ablin, Hugo Richard
+#
+# License: MIT
 
 import numpy as np
 from scipy import linalg

--- a/mvlearn/embed/base.py
+++ b/mvlearn/embed/base.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from abc import abstractmethod
 

--- a/mvlearn/embed/dcca.py
+++ b/mvlearn/embed/dcca.py
@@ -1,17 +1,3 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # Original work Copyright (c) 2016 Vahid Noroozi
 # Modified work Copyright 2019 Zhanghao Wu
 

--- a/mvlearn/embed/gcca.py
+++ b/mvlearn/embed/gcca.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from .base import BaseEmbed
 from ..utils.utils import check_Xs

--- a/mvlearn/embed/kcca.py
+++ b/mvlearn/embed/kcca.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Adopted from Steven Van Vaerenbergh's MATLAB Package 'KMBOX'
 # https://github.com/steven2358/kmbox

--- a/mvlearn/embed/mvmds.py
+++ b/mvlearn/embed/mvmds.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from .base import BaseEmbed
 from ..utils.utils import check_Xs

--- a/mvlearn/embed/splitae.py
+++ b/mvlearn/embed/splitae.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 import sys
 import itertools

--- a/mvlearn/embed/utils.py
+++ b/mvlearn/embed/utils.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 from scipy.stats import norm
 import numpy as np

--- a/mvlearn/model_selection/split.py
+++ b/mvlearn/model_selection/split.py
@@ -1,17 +1,6 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 # Authors: Alexander Chang, Gavin Mischler
+#
+# License: MIT
 
 import numpy as np
 from sklearn import model_selection as ms

--- a/mvlearn/model_selection/validation.py
+++ b/mvlearn/model_selection/validation.py
@@ -1,18 +1,8 @@
 """Validation utils."""
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 # Authors: Pierre Ablin
+#
+# License: MIT
+
 import numpy as np
 
 from sklearn.model_selection import cross_validate as sk_cross_validate

--- a/mvlearn/plotting/plot.py
+++ b/mvlearn/plotting/plot.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 import matplotlib.pyplot as plt
 import seaborn as sns

--- a/mvlearn/preprocessing/repeat.py
+++ b/mvlearn/preprocessing/repeat.py
@@ -1,18 +1,8 @@
 """Filtering module."""
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 # Authors: Pierre Ablin
+#
+# License: MIT
 
 from sklearn.base import clone, TransformerMixin
 from sklearn.utils.validation import check_is_fitted

--- a/mvlearn/semi_supervised/base.py
+++ b/mvlearn/semi_supervised/base.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # This is a base class for implementing multi-view estimators using
 # co-training.

--- a/mvlearn/semi_supervised/ctclassifier.py
+++ b/mvlearn/semi_supervised/ctclassifier.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Implements multi-view co-training classification for 2-view data.
 

--- a/mvlearn/semi_supervised/ctregression.py
+++ b/mvlearn/semi_supervised/ctregression.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 #
 # Implements multi-view co-training regression for 2-view data.
 

--- a/mvlearn/utils/utils.py
+++ b/mvlearn/utils/utils.py
@@ -1,16 +1,4 @@
-# Copyright 2019 NeuroData (http://neurodata.io)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# License: MIT
 
 import numpy as np
 from sklearn.utils import check_X_y, check_array


### PR DESCRIPTION
Solves #221 to switch from Neurodata Apache 2.0 to MIT licence
- Updates the License file accordingly, as well as the webdocs license page.
- Updates all files and examples accordingly as well.