### PR TITLE
add train_test_split to rst

### DIFF
--- a/docs/references/model_selection.rst
+++ b/docs/references/model_selection.rst
@@ -7,3 +7,8 @@ Cross Validation
 ----------------
 
 .. autofunction:: cross_validate
+
+Train-Test Split
+----------------
+
+.. autofunction:: train_test_split

--- a/mvlearn/model_selection/split.py
+++ b/mvlearn/model_selection/split.py
@@ -95,7 +95,6 @@ def train_test_split(*inputs, **options):
     # Print test set
     >>> for i in range(len(Xs_test)):
     ...     print('Xs_test[%d]' % i, Xs_test[i], sep='\n')
-
     Xs_test[0]
     [[0 1]]
     Xs_test[1]

--- a/mvlearn/model_selection/split.py
+++ b/mvlearn/model_selection/split.py
@@ -55,8 +55,8 @@ def train_test_split(*inputs, **options):
 
     Examples
     --------
-    >>> from mvlearn.preprocessing import train_test_split
     >>> import numpy as np
+    >>> from mvlearn.preprocessing import train_test_split
     >>> Xs = np.arange(18).reshape((3, 3, 2))
     >>> y = np.arange(3)
     >>> # Print the data


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/mvlearn/mvlearn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The train_test_split function was not being rendered in the docs because it wasn't in the rst file.

#### Any other comments?
Also fixes import order of the train_test_split docstring example
