### PR TITLE
Plotting minor tick deprecation fix

### DIFF
--- a/mvlearn/compose/merge.py
+++ b/mvlearn/compose/merge.py
@@ -72,8 +72,8 @@ class BaseMerger(TransformerMixin):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
         y : array, shape (n_samples,), optional
 
         Returns

--- a/mvlearn/decomposition/ajive.py
+++ b/mvlearn/decomposition/ajive.py
@@ -276,8 +276,8 @@ class AJIVE(BaseDecomposer):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             The data to fit to.
 
         y : None

--- a/mvlearn/decomposition/base.py
+++ b/mvlearn/decomposition/base.py
@@ -66,8 +66,8 @@ class BaseDecomposer(BaseEstimator):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
         y : array, shape (n_samples,), optional
 
         Returns

--- a/mvlearn/decomposition/groupica.py
+++ b/mvlearn/decomposition/groupica.py
@@ -160,8 +160,8 @@ class GroupICA(BaseDecomposer):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
 
         y : None
             Ignored variable.

--- a/mvlearn/decomposition/grouppca.py
+++ b/mvlearn/decomposition/grouppca.py
@@ -162,8 +162,8 @@ class GroupPCA(BaseDecomposer):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
 
         y : None
             Ignored variable.

--- a/mvlearn/embed/dcca.py
+++ b/mvlearn/embed/dcca.py
@@ -613,8 +613,8 @@ class DCCA(BaseEmbed):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             The data to fit to. Each view will receive its own embedding.
 
         y : ignored
@@ -702,8 +702,8 @@ class DCCA(BaseEmbed):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             A list of data matrices from each view to transform based on the
             prior fit function. If view_idx defined, then Xs is a 2D data
             matrix corresponding to a single view.

--- a/mvlearn/embed/gcca.py
+++ b/mvlearn/embed/gcca.py
@@ -164,8 +164,8 @@ class GCCA(BaseEmbed):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             The data to fit to. Each view will receive its own embedding.
         y : ignored
             Included for API compliance.
@@ -203,8 +203,8 @@ class GCCA(BaseEmbed):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             The data to fit to. Each view will receive its own embedding.
         reset : boolean (default = False)
             If True, overwrites all prior computations.
@@ -362,8 +362,8 @@ class GCCA(BaseEmbed):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             A list of data matrices from each view to transform based on the
             prior fit function. If view_idx is defined, then Xs is a 2D data
             matrix corresponding to a single view.

--- a/mvlearn/embed/omnibus.py
+++ b/mvlearn/embed/omnibus.py
@@ -148,8 +148,8 @@ class Omnibus(BaseEmbed):
         Parameters
         ==========
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             The data to embed based on the prior fit function. Each
             X in Xs will receive its own embedding.
         y : ignored
@@ -178,8 +178,8 @@ class Omnibus(BaseEmbed):
         Parameters
         ==========
          Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
             The data to embed based on the prior fit function. Each
             X in Xs will receive its own embedding.
         y : ignored

--- a/mvlearn/plotting/plot.py
+++ b/mvlearn/plotting/plot.py
@@ -117,8 +117,8 @@ def crossviews_plot(
         if dim1 == dim2 and equal_axes:
             ax.axis("equal")
         if not ax_ticks:
-            ax.set_xticks([], [])
-            ax.set_yticks([], [])
+            ax.set_xticks([])
+            ax.set_yticks([])
 
     if title is not None:
         plt.tight_layout(rect=[0, 0.03, 1, 0.95])
@@ -223,8 +223,8 @@ def quick_visualize(
         plt.xlabel("Component 1")
         plt.ylabel("Component 2")
     if not ax_ticks:
-        plt.xticks([], [])
-        plt.yticks([], [])
+        plt.xticks([])
+        plt.yticks([])
 
     if title is not None:
         plt.tight_layout(rect=[0, 0.03, 1, 0.95])

--- a/mvlearn/semi_supervised/base.py
+++ b/mvlearn/semi_supervised/base.py
@@ -99,8 +99,8 @@ class BaseCoTrainEstimator(BaseEstimator):
         Parameters
         ----------
         Xs : list of array-likes or numpy.ndarray
-             - Xs length: n_views
-             - Xs[i] shape: (n_samples, n_features_i)
+            - Xs length: n_views
+            - Xs[i] shape: (n_samples, n_features_i)
              A list of the different views of data to fit and
              then predict.
         y : array, shape (n_samples,)


### PR DESCRIPTION
#### Reference Issues/PRs
Solves #243 by removing two references to minor tick labels in the plotting files.

Also fixes bullet points in docstrings in a bunch of files. Incorrect spacing led to incorrect rendering. No other bullets should be misspecified at this point.


