### PR TITLE
gaussian mixture dataset update

### DIFF
--- a/docs/references/datasets.rst
+++ b/docs/references/datasets.rst
@@ -11,7 +11,7 @@ UCI multiple feature dataset (located `here <https://archive.ics.uci.edu/ml/data
 Data Simulator
 --------------
 
-.. autoclass:: GaussianMixture
+.. autofunction:: make_gaussian_mixture
 
 Factor Model
 ------------

--- a/examples/datasets/plot_gaussianmixtures.py
+++ b/examples/datasets/plot_gaussianmixtures.py
@@ -11,7 +11,7 @@ mixtures and plot the views against each other using a crossviews plot.
 # License: MIT
 
 import numpy as np
-from mvlearn.datasets import GaussianMixture
+from mvlearn.datasets import make_gaussian_mixture
 from mvlearn.plotting import crossviews_plot
 
 # Latent variables are sampled from two multivariate Gaussians with equal
@@ -21,12 +21,11 @@ from mvlearn.plotting import crossviews_plot
 n_samples = 100
 centers = [[0, 1], [0, -1]]
 covariances = [np.eye(2), np.eye(2)]
-gm = GaussianMixture(n_samples, centers, covariances, random_state=42,
-                     shuffle=True, shuffle_random_state=42)
-gm = gm.sample_views(transform='poly', n_noise=2)
+Xs, y, latent = make_gaussian_mixture(
+    n_samples, centers, covariances, random_state=42, noise_dims=2,
+    shuffle=True, shuffle_random_state=42, transform='poly',
+    return_latents=True)
 
-latent, y = gm.get_Xy(latents=True)
-Xs, _ = gm.get_Xy(latents=False)
 
 # The latent data is plotted against itself to reveal the underlying
 # distribtution.

--- a/examples/embed/plot_cca_comparison.py
+++ b/examples/embed/plot_cca_comparison.py
@@ -33,7 +33,7 @@ views.
 # License: MIT
 
 from mvlearn.embed import CCA, KMCCA, DCCA
-from mvlearn.datasets import GaussianMixture
+from mvlearn.datasets import make_gaussian_mixture
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib
@@ -41,31 +41,28 @@ import seaborn as sns
 import warnings
 warnings.filterwarnings("ignore")
 
-# Make Latents
+# GMM settings
 n_samples = 200
-centers = [[0, 1], [0, -1]]
-covariances = 2*np.array([np.eye(2), np.eye(2)])
-gm_train = GaussianMixture(n_samples, centers, covariances)
-
-# Test
-gm_test = GaussianMixture(n_samples, centers, covariances)
-
-# Make 2 views
-n_noise = 2
+centers = [[0, 0], [0, 0]]
+covariances = 4*np.array([np.eye(2), np.eye(2)])
 transforms = ['linear', 'poly', 'sin']
 
-Xs_train = []
-Xs_test = []
+Xs_train_sets = []
+Xs_test_sets = []
 for transform in transforms:
-    gm_train.sample_views(transform=transform, n_noise=n_noise)
-    gm_test.sample_views(transform=transform, n_noise=n_noise)
+    Xs_train, _ = make_gaussian_mixture(
+        n_samples, centers, covariances, transform=transform, noise=0.25,
+        noise_dims=2, random_state=1)
+    Xs_test, _, latents = make_gaussian_mixture(
+        n_samples, centers, covariances, transform=transform, noise=0.25,
+        noise_dims=2, random_state=2, return_latents=True)
 
-    Xs_train.append(gm_train.get_Xy()[0])
-    Xs_test.append(gm_test.get_Xy()[0])
+    Xs_train_sets.append(Xs_train)
+    Xs_test_sets.append(Xs_test)
 
 
 # Plotting parameters
-labels = gm_test.latent_[:, 0]
+labels = latents[:, 0]
 cmap = matplotlib.colors.ListedColormap(
     sns.diverging_palette(240, 10, n=len(labels), center='light').as_hex())
 cmap = 'coolwarm'
@@ -75,8 +72,9 @@ method_labels = \
 transform_labels = \
     ['Linear Transform', 'Polynomial Transform', 'Sinusoidal Transform']
 
-input_size1, input_size2 = Xs_train[0][0].shape[1], Xs_train[0][1].shape[1]
-outdim_size = min(Xs_train[0][0].shape[1], 2)
+input_size1 = Xs_train_sets[0][0].shape[1]
+input_size2 = Xs_train_sets[0][1].shape[1]
+outdim_size = min(Xs_train_sets[0][0].shape[1], 2)
 layer_sizes1 = [256, 256, outdim_size]
 layer_sizes2 = [256, 256, outdim_size]
 methods = [
@@ -98,8 +96,8 @@ for r, transform in enumerate(transforms):
         dim2 = int(i / 2)
         dim1 = i % 2
         ax.scatter(
-            Xs_test[r][0][:, dim1],
-            Xs_test[r][1][:, dim2],
+            Xs_test_sets[r][0][:, dim1],
+            Xs_test_sets[r][1][:, dim2],
             cmap=cmap,
             c=labels,
         )
@@ -118,7 +116,7 @@ for r, transform in enumerate(transforms):
 
     for c, method in enumerate(methods):
         axs = axes[2*r: 2*r+2, 2*c+2:2*c+4]
-        Xs = method.fit(Xs_train[r]).transform(Xs_test[r])
+        Xs = method.fit(Xs_train_sets[r]).transform(Xs_test_sets[r])
         for i, ax in enumerate(axs.flatten()):
             dim2 = int(i / 2)
             dim1 = i % 2

--- a/examples/embed/plot_cca_comparison.py
+++ b/examples/embed/plot_cca_comparison.py
@@ -52,10 +52,10 @@ Xs_test_sets = []
 for transform in transforms:
     Xs_train, _ = make_gaussian_mixture(
         n_samples, centers, covariances, transform=transform, noise=0.25,
-        noise_dims=2, random_state=1)
+        noise_dims=2, random_state=41)
     Xs_test, _, latents = make_gaussian_mixture(
         n_samples, centers, covariances, transform=transform, noise=0.25,
-        noise_dims=2, random_state=2, return_latents=True)
+        noise_dims=2, random_state=42, return_latents=True)
 
     Xs_train_sets.append(Xs_train)
     Xs_test_sets.append(Xs_test)

--- a/examples/embed/plot_dcca_tutorial.py
+++ b/examples/embed/plot_dcca_tutorial.py
@@ -19,7 +19,7 @@ this information in a low dimensional embedding.
 
 import numpy as np
 from mvlearn.embed import DCCA
-from mvlearn.datasets import GaussianMixture
+from mvlearn.datasets import make_gaussian_mixture
 from mvlearn.plotting import crossviews_plot
 from mvlearn.model_selection import train_test_split
 
@@ -36,9 +36,9 @@ from mvlearn.model_selection import train_test_split
 n_samples = 2000
 means = [[0, 1], [0, -1]]
 covariances = [np.eye(2), np.eye(2)]
-gm = GaussianMixture(n_samples, means, covariances, random_state=42,
-                     shuffle=True, shuffle_random_state=42)
-latent, y = gm.get_Xy(latents=True)
+Xs, y, latent = make_gaussian_mixture(
+      n_samples, means, covariances, transform='poly', random_state=42,
+      shuffle=True, shuffle_random_state=42, return_latents=True)
 
 # Plot latent data against itself to reveal the underlying distribtution.
 crossviews_plot([latent, latent], labels=y,
@@ -46,7 +46,6 @@ crossviews_plot([latent, latent], labels=y,
 
 
 # Split data into train and test sets
-Xs, y = gm.sample_views(transform='poly', n_noise=2).get_Xy()
 Xs_train, Xs_test, y_train, y_test = train_test_split(Xs, y, test_size=0.3,
                                                       random_state=42)
 
@@ -100,11 +99,11 @@ crossviews_plot(Xs_transformed, labels=y_test,
 n_samples = 2000
 means = [[0, 1], [0, -1]]
 covariances = [np.eye(2), np.eye(2)]
-gm = GaussianMixture(n_samples, means, covariances, random_state=42,
-                     shuffle=True, shuffle_random_state=42)
+Xs, y, latent = make_gaussian_mixture(
+      n_samples, means, covariances, transform='sin', random_state=42,
+      shuffle=True, shuffle_random_state=42, return_latents=True, noise_dims=2)
 
 # Split data into train and test segments
-Xs, y = gm.sample_views(transform='sin', n_noise=2).get_Xy()
 Xs_train, Xs_test, y_train, y_test = train_test_split(Xs, y, test_size=0.3,
                                                       random_state=42)
 

--- a/examples/plotting/plot_crossviews_plot.py
+++ b/examples/plotting/plot_crossviews_plot.py
@@ -13,7 +13,7 @@ simulated from transformations of multi-variant gaussians.
 
 # License: MIT
 
-from mvlearn.datasets import GaussianMixture
+from mvlearn.datasets import make_gaussian_mixture
 from mvlearn.plotting import crossviews_plot
 import numpy as np
 
@@ -21,13 +21,13 @@ import numpy as np
 n_samples = 100
 centers = [[0, 1], [0, -1]]
 covariances = [np.eye(2), np.eye(2)]
-GM = GaussianMixture(n_samples, centers, covariances, shuffle=True)
-GM = GM.sample_views(transform='poly', n_noise=2)
+Xs, y = make_gaussian_mixture(
+    n_samples, centers, covariances, transform='poly', noise_dims=2, shuffle=True)
 
 # Below, we see that the first two dimensions are related by a degree 2
 # polynomial while the latter two dimensions are uncorrelated.
 
 
-crossviews_plot(GM.Xs_, labels=GM.y_,
+crossviews_plot(Xs, labels=y,
                 title='View 1 vs. View 2 (Polynomial \
                     Transform + noise)', equal_axes=True)

--- a/examples/plotting/plot_crossviews_plot.py
+++ b/examples/plotting/plot_crossviews_plot.py
@@ -22,7 +22,7 @@ n_samples = 100
 centers = [[0, 1], [0, -1]]
 covariances = [np.eye(2), np.eye(2)]
 Xs, y = make_gaussian_mixture(
-    n_samples, centers, covariances, transform='poly', noise_dims=2, shuffle=True)
+    n_samples, centers, covariances, transform='poly', noise_dims=2)
 
 # Below, we see that the first two dimensions are related by a degree 2
 # polynomial while the latter two dimensions are uncorrelated.

--- a/mvlearn/datasets/__init__.py
+++ b/mvlearn/datasets/__init__.py
@@ -1,9 +1,9 @@
 from .base import load_UCImultifeature
-from .gaussian_mixture import GaussianMixture
+from .gaussian_mixture import make_gaussian_mixture
 from .factor_model import sample_joint_factor_model
 
 __all__ = [
     "load_UCImultifeature",
-    "GaussianMixture",
+    "make_gaussian_mixture",
     "sample_joint_factor_model"
     ]

--- a/mvlearn/datasets/gaussian_mixture.py
+++ b/mvlearn/datasets/gaussian_mixture.py
@@ -112,13 +112,7 @@ def make_gaussian_mixture(
         raise ValueError(msg)
     if centers.shape[0] != covariances.shape[0]:
         msg = "The first dimensions of 2D centers and 3D covariances" + \
-            "must be equal"
-        raise ValueError(msg)
-    if centers.dtype == np.dtype(
-        "O"
-    ) or covariances.dtype == np.dtype("O"):
-        msg = "elements of covariances or centers are of " + \
-            "inconsistent lengths or are not floats nor ints"
+            " must be equal"
         raise ValueError(msg)
     if class_probs is None:
         class_probs = np.ones(centers.shape[0])

--- a/mvlearn/datasets/gaussian_mixture.py
+++ b/mvlearn/datasets/gaussian_mixture.py
@@ -87,13 +87,13 @@ def make_gaussian_mixture(
 
     Examples
     --------
-    >>> from mvlearn.datasets import GaussianMixture
+    >>> from mvlearn.datasets import make_gaussian_mixture
     >>> import numpy as np
     >>> n_samples = 10
     >>> centers = [[0,1], [0,-1]]
     >>> covariances = [np.eye(2), np.eye(2)]
-    >>> Xs, y = GaussianMixture(n_samples, centers, covariances,
-    ...                         shuffle=True, shuffle_random_state=42)
+    >>> Xs, y = make_gaussian_mixture(n_samples, centers, covariances,
+    ...                               shuffle=True, shuffle_random_state=42)
     >>> print(y)
     [1. 0. 1. 0. 1. 0. 1. 0. 0. 1.]
     """

--- a/tests/datasets/test_gaussian_mixture.py
+++ b/tests/datasets/test_gaussian_mixture.py
@@ -1,15 +1,15 @@
 import pytest
-from mvlearn.datasets import GaussianMixture
+from mvlearn.datasets import make_gaussian_mixture
 from numpy.testing import assert_equal
 import numpy as np
 
 
 n_samples = 100
-gm_uni = GaussianMixture(n_samples, [0, 1], np.eye(2))
+Xs_uni, y_uni = make_gaussian_mixture(n_samples, [0, 1], np.eye(2))
 centers = [[-1, 0], [1, 0]]
 covariances = [[[1, 0], [0, 1]], [[1, 0], [1, 2]]]
 class_probs = [0.3, 0.7]
-gm_centerslti = GaussianMixture(n_samples, centers, covariances, class_probs)
+Xs_lti, y_lti = make_gaussian_mixture(n_samples, centers, covariances, class_probs)
 
 
 def test_centersltivariate():
@@ -35,7 +35,7 @@ def test_transforms():
 
 def test_bad_class_probs():
     with pytest.raises(ValueError):
-        GaussianMixture(
+        make_gaussian_mixture(
             centers, covariances, n_samples, class_probs=[0.3, 0.4]
         )
 
@@ -51,7 +51,7 @@ def test_bad_transform_string():
 
 
 def test_no_sample():
-    gaussm = GaussianMixture(n_samples, centers, covariances, class_probs)
+    gaussm = make_gaussian_mixture(n_samples, centers, covariances, class_probs)
     with pytest.raises(NameError):
         gaussm.get_Xy()
 
@@ -59,29 +59,29 @@ def test_no_sample():
 def test_bad_shapes():
     ## Wrong Length
     with pytest.raises(ValueError):
-        GaussianMixture(n_samples, [1], covariances)
+        make_gaussian_mixture(n_samples, [1], covariances)
     ## Inconsistent dimension
     with pytest.raises(ValueError):
-        GaussianMixture(
+        make_gaussian_mixture(
             n_samples, centers, [np.eye(2), np.eye(3)], class_probs
         )
     ## Wrong uni dimensions
     with pytest.raises(ValueError):
-        GaussianMixture(n_samples, [1, 0], [1, 0])
+        make_gaussian_mixture(n_samples, [1, 0], [1, 0])
     ## Wrong centerslti sizes
     with pytest.raises(ValueError):
-        GaussianMixture(
+        make_gaussian_mixture(
             n_samples, centers, covariances, class_probs=[0.3, 0.1, 0.6]
         )
 
 
 def test_random_state():
-    gm_1 = GaussianMixture(
+    gm_1 = make_gaussian_mixture(
         10, centers, covariances, class_probs, random_state=42
     )
     gm_1.sample_views("poly")
     Xs_1, y_1 = gm_1.get_Xy()
-    gm_2 = GaussianMixture(
+    gm_2 = make_gaussian_mixture(
         10, centers, covariances, class_probs, random_state=42
     )
     gm_2.sample_views("poly")
@@ -92,14 +92,14 @@ def test_random_state():
 
 
 def test_noise_dims_not_same_but_reproducible():
-    gm_1 = GaussianMixture(
+    gm_1 = make_gaussian_mixture(
         20, centers, covariances, class_probs, random_state=42
     )
     gm_1.sample_views("poly", n_noise=2)
     Xs_2, _ = gm_1.get_Xy()
     view1_noise, view2_noise = Xs_2[0][:, -2:], Xs_2[1][:, -2:]
     assert not np.allclose(view1_noise, view2_noise)
-    gm_2 = GaussianMixture(
+    gm_2 = make_gaussian_mixture(
         20, centers, covariances, class_probs, random_state=42
     )
     gm_2.sample_views("poly", n_noise=2)
@@ -111,7 +111,7 @@ def test_noise_dims_not_same_but_reproducible():
 
 def test_shuffle():
     np.random.seed(42)
-    gm_1 = GaussianMixture(
+    gm_1 = make_gaussian_mixture(
         20,
         centers,
         covariances,
@@ -123,7 +123,7 @@ def test_shuffle():
     gm_1.sample_views("poly")
     Xs_1, y_1 = gm_1.get_Xy()
     np.random.seed(30)
-    gm_2 = GaussianMixture(
+    gm_2 = make_gaussian_mixture(
         20,
         centers,
         covariances,
@@ -140,7 +140,7 @@ def test_shuffle():
 
 
 def test_shuffle_with_random_state():
-    gm_1 = GaussianMixture(
+    gm_1 = make_gaussian_mixture(
         20,
         centers,
         covariances,
@@ -151,7 +151,7 @@ def test_shuffle_with_random_state():
     )
     gm_1.sample_views("poly")
     Xs_1, y_1 = gm_1.get_Xy()
-    gm_2 = GaussianMixture(
+    gm_2 = make_gaussian_mixture(
         20,
         centers,
         covariances,


### PR DESCRIPTION
Two relatively minor changes:
1. The GaussianMixture dataset was changed from a class to a function to better reflect the other datasets and to make it less, unnecessarily complicated.

2. Previously, the two returned views were [latent_vars, transformation(latent_vars)]. Functionality was added to add gaussian noise to the first view (latent_vars) so that the two views aren't deterministically related. This updates the cca comparison example to reflect its condensed version in the paper.