### PR TITLE
Fixes CCA to only take integer n_components values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,7 +31,7 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 Unreleased
 ----------
 
-- [Fix] ``CCA`` now only acepts integer arguments for ``n_components``, upper bounded by the minimum number of view features. Previously it accepted options that ``MCCA`` accepted which are only valid for greater than two views. This also had the effect of errors with ``cca.get_stats``.
+- [Fix] ``CCA`` now only acepts integer arguments for ``n_components``, upper bounded by the minimum number of view features. Previously it accepted options that ``MCCA`` accepted which are only valid for greater than two views. This also had the effect of errors with ``cca.get_stats``. `#279 <https://github.com/mvlearn/mvlearn/pull/279>` by `Ronan Perry`_.
 
 Version 0.4.1
 -------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,11 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+Unreleased
+----------
+
+- [Fix] ``CCA`` now only acepts integer arguments for ``n_components``, upper bounded by the minimum number of view features. Previously it accepted options that ``MCCA`` accepted which are only valid for greater than two views. This also had the effect of errors with ``cca.get_stats``.
+
 Version 0.4.1
 -------------
 

--- a/mvlearn/embed/cca.py
+++ b/mvlearn/embed/cca.py
@@ -18,13 +18,11 @@ class CCA(MCCA):
 
     Parameters
     ----------
-    n_components : int | 'min' | 'max' | None (default 1)
-        Number of final components to compute. If `int`, will compute that
-        many. If None, will compute as many as possible. 'min' and 'max' will
-        respectively use the minimum/maximum number of features among views.
+    n_components : int (default 1)
+        Number of canonical components to compute and return.
 
     regs : float | 'lw' | 'oas' | None, or list, optional (default None)
-        MCCA regularization for each data view, which can be important
+        CCA regularization for each data view, which can be important
         for high dimensional data. A list will specify for each view
         separately. If float, must be between 0 and 1 (inclusive).
 
@@ -109,6 +107,11 @@ class CCA(MCCA):
             raise ValueError(
                 f"CCA accepts exactly 2 views but {self.n_views_}"
                 "were provided. Consider using MCCA for more than 2 views")
+        if not (type(self.n_components) == int and
+                1 <= self.n_components <= min(self.n_features_)):
+            raise ValueError(
+                "n_components must be an integer in the range"
+                f"[1, {min(self.n_features_)}]")
 
         centers = param_as_list(self.center, self.n_views_)
         self.means_ = [np.mean(X, axis=0) if c else None

--- a/mvlearn/embed/cca.py
+++ b/mvlearn/embed/cca.py
@@ -4,6 +4,7 @@
 # License: MIT
 
 import numpy as np
+import numbers
 from scipy.stats import f, chi2
 from sklearn.utils.validation import check_is_fitted
 from .mcca import MCCA, _i_mcca, _mcca_gevp
@@ -107,7 +108,7 @@ class CCA(MCCA):
             raise ValueError(
                 f"CCA accepts exactly 2 views but {self.n_views_}"
                 "were provided. Consider using MCCA for more than 2 views")
-        if not (type(self.n_components) == int and
+        if not (isinstance(self.n_components, numbers.Integral) and
                 1 <= self.n_components <= min(self.n_features_)):
             raise ValueError(
                 "n_components must be an integer in the range"

--- a/tests/embed/test_cca.py
+++ b/tests/embed/test_cca.py
@@ -97,6 +97,16 @@ def test_errors():
         _ = cca.stats([train1, train1], 'FAIL')
 
 
+@pytest.mark.parametrize(
+    "n_components",
+    [None, 0, 'min', 'max', min((train1.shape[1], train2.shape[1]))+1]
+    )
+def test_n_components(n_components):
+    cca = CCA(n_components=n_components)
+    with pytest.raises(ValueError, match="n_components must be an integer"):
+        cca = cca.fit([train1, train2])
+
+
 # Test getting stats correctly, and check against stats that
 # Matlab canoncorr gives
 def test_stats_vs_matlab():

--- a/tests/embed/test_cca.py
+++ b/tests/embed/test_cca.py
@@ -174,7 +174,7 @@ def test_stats_1_component():
         'pChisq': np.array([0.9609454])
         }
 
-    cca = CCA(n_components=1)
+    cca = CCA(n_components=np.int64(1))
     scores = cca.fit_transform([X, Y])
     stats = cca.stats(scores)
 


### PR DESCRIPTION
#### Reference Issues/PRs
Addresses #278 which was the result of an error with CCA

#### What does this implement/fix? Explain your changes.
Previously CCA inherited all `n_components` arguments from MCCA but for two views only integers from 1 to the minimum number of features among views is permissible. >2 views this is not the case.

