### PR TITLE
remove extra hyperlink in uci multifeature dataset

### DIFF
--- a/docs/references/datasets.rst
+++ b/docs/references/datasets.rst
@@ -3,8 +3,8 @@ Multiview Datasets
 
 .. currentmodule:: mvlearn.datasets
 
-UCI multiple feature dataset (located `here <https://archive.ics.uci.edu/ml/datasets/Multiple+Features>`_)
-----------------------------------------------------------------------------------------------------------
+UCI multiple feature dataset
+----------------------------
 
 .. autofunction:: load_UCImultifeature
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/mvlearn/mvlearn/blob/main/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
There is an unnecessary extra link to the UCI multiple feature dataset that shows up in the docs. The same link is provided in the description of the function, so it is unnecessary in the header, and makes the sidebar look worse

#### Any other comments?

