### PR TITLE
CV: GridSearchCV and RandomizedSearchCV

### DIFF
--- a/mvlearn/model_selection/__init__.py
+++ b/mvlearn/model_selection/__init__.py
@@ -1,4 +1,5 @@
 from .split import train_test_split
 from .validation import cross_validate
+from ._search import GridSearchCV, RandomizedSearchCV
 
-__all__ = ["train_test_split", "cross_validate", ]
+__all__ = ["train_test_split", "cross_validate", "GridSearchCV", "RandomizedSearchCV"]

--- a/mvlearn/model_selection/_search.py
+++ b/mvlearn/model_selection/_search.py
@@ -117,11 +117,11 @@ class ParameterSampler:
             for key in dist:
                 if isinstance(dist[key], Iterable):
                     if any(
-                        [
-                            not isinstance(view_param, Iterable)
-                            and not hasattr(view_param, "rvs")
-                            for view_param in dist[key]
-                        ]
+                            [
+                                not isinstance(view_param, Iterable)
+                                and not hasattr(view_param, "rvs")
+                                for view_param in dist[key]
+                            ]
                     ):
                         raise TypeError(
                             "Parameter value for at least one view is not iterable "
@@ -149,35 +149,16 @@ class ParameterSampler:
                 # if value is an iterable then either the elements are the distribution or each element is a distribution
                 # for each view.
                 if isinstance(v, Iterable):
-                    # if the parameter is shared across views then the list will just contain non-iterable values
-                    if not any(
-                        [
-                            (isinstance(v_, Iterable) and not isinstance(v_, str))
-                            for v_ in v
-                        ]
-                    ):
-                        params[k] = self.return_param(v)
                     # if each element is a distribution for each view (i.e. it is a non-string Iterable) then call return_param for each view
-                    else:
+                    if any([(isinstance(v_, Iterable) and not isinstance(v_, str)) for v_ in v]):
                         params[k] = [self.return_param(v_) for v_ in v]
+                    # if the parameter is shared across views then the list will just contain non-iterable values
+                    else:
+                        params[k] = self.return_param(v)
                 # if value is not iterable then it is either a distribution or a value in which case call return param on it.
                 else:
                     params[k] = self.return_param(v)
             yield params
-
-    def return_param(self, v):
-        rng = check_random_state(self.random_state)
-        if hasattr(v, "rvs"):
-            param = v.rvs(random_state=rng)
-        elif isinstance(v, Iterable) and not isinstance(v, str):
-            param = v[rng.randint(len(v))]
-        else:
-            param = v
-        return param
-
-    def __len__(self):
-        """Number of points that will be sampled."""
-        return self.n_iter
 
 
 class BaseSearchCV(SKBaseSearchCV):

--- a/mvlearn/model_selection/_search.py
+++ b/mvlearn/model_selection/_search.py
@@ -150,7 +150,7 @@ class ParameterSampler:
                 # for each view.
                 if isinstance(v, Iterable):
                     # if each element is a distribution for each view (i.e. it is a non-string Iterable) then call return_param for each view
-                    if any([(isinstance(v_, Iterable) and not isinstance(v_, str)) for v_ in v]):
+                    if any([(isinstance(v_, Iterable) and not isinstance(v_, str)) or hasattr(v_,'rvs') for v_ in v]):
                         params[k] = [self.return_param(v_) for v_ in v]
                     # if the parameter is shared across views then the list will just contain non-iterable values
                     else:

--- a/mvlearn/model_selection/_search.py
+++ b/mvlearn/model_selection/_search.py
@@ -1,3 +1,15 @@
+"""
+utilities to fine-tune theparameters of a multi-view estimator.
+"""
+# Author: James Chapman
+# Original Authors:
+#         Alexandre Gramfort <alexandre.gramfort@inria.fr>,
+#         Gael Varoquaux <gael.varoquaux@normalesup.org>
+#         Andreas Mueller <amueller@ais.uni-bonn.de>
+#         Olivier Grisel <olivier.grisel@ensta.org>
+#         Raghav RV <rvraghav93@gmail.com>
+# MIT
+
 import itertools
 import numbers
 import time

--- a/mvlearn/model_selection/_search.py
+++ b/mvlearn/model_selection/_search.py
@@ -586,7 +586,6 @@ class GridSearchCV(BaseSearchCV):
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
         This is present only if ``refit`` is not False.
-        .. versionadded:: 0.20
     multimetric_ : bool
         Whether or not the scorers compute several metrics.
     classes_ : ndarray of shape (n_classes,)
@@ -597,13 +596,11 @@ class GridSearchCV(BaseSearchCV):
         `best_estimator_` is defined (see the documentation for the `refit`
         parameter for more details) and that `best_estimator_` exposes
         `n_features_in_` when fit.
-        .. versionadded:: 0.24
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
         parameter for more details) and that `best_estimator_` exposes
         `feature_names_in_` when fit.
-        .. versionadded:: 1.0
     Notes
     -----
     The parameters selected are those that maximize the score of the left out
@@ -851,7 +848,6 @@ class RandomizedSearchCV(BaseSearchCV):
     refit_time_ : float
         Seconds used for refitting the best model on the whole dataset.
         This is present only if ``refit`` is not False.
-        .. versionadded:: 0.20
     multimetric_ : bool
         Whether or not the scorers compute several metrics.
     classes_ : ndarray of shape (n_classes,)
@@ -862,13 +858,11 @@ class RandomizedSearchCV(BaseSearchCV):
         `best_estimator_` is defined (see the documentation for the `refit`
         parameter for more details) and that `best_estimator_` exposes
         `n_features_in_` when fit.
-        .. versionadded:: 0.24
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of features seen during :term:`fit`. Only defined if
         `best_estimator_` is defined (see the documentation for the `refit`
         parameter for more details) and that `best_estimator_` exposes
         `feature_names_in_` when fit.
-        .. versionadded:: 1.0
     Notes
     -----
     The parameters selected are those that maximize the score of the held-out

--- a/mvlearn/model_selection/_search.py
+++ b/mvlearn/model_selection/_search.py
@@ -1,0 +1,924 @@
+import itertools
+import numbers
+import time
+from collections import defaultdict
+from itertools import product
+from typing import Mapping, Iterable
+
+import numpy as np
+from joblib import Parallel
+from sklearn import clone
+from sklearn.base import is_classifier
+from sklearn.metrics import check_scoring
+from sklearn.metrics._scorer import _check_multimetric_scoring
+from sklearn.model_selection import check_cv
+from sklearn.model_selection._search import (
+    BaseSearchCV as SKBaseSearchCV,
+    ParameterGrid,
+    _check_param_grid,
+)
+from sklearn.model_selection._validation import _fit_and_score, _insert_error_scores
+from sklearn.pipeline import Pipeline
+from sklearn.utils import indexable
+from sklearn.utils.fixes import delayed
+from sklearn.utils.validation import _check_fit_params, check_random_state
+
+from mvlearn.compose import SimpleSplitter
+from mvlearn.utils import check_Xs
+
+
+def param2grid(params):
+    """
+    Converts parameters with a list for each view into a scikit-learn friendly form
+
+    Parameters
+    ----------
+    params : a dictionary of parameters where some parameters may contain a list of lists (one list for each 'view')
+
+    Returns : a parameter grid in the form expected by scikit-learn where each element is a single candidate
+    (a single value or a list with one value for each view)
+    -------
+
+    Examples
+    ---------
+    >>> params = {
+    >>>     'regs': [[1, 2], [3, 4]],
+    >>> }
+    >>> param2grid(params)
+    >>> [[1,3], [1,4], [2,3], [2,4]]
+    """
+    for k, v in params.items():
+        if any([isinstance(v_, list) for v_ in v]):
+            #itertools expects all lists to perform product
+            v=[[v_] if not isinstance(v_, list) else v_ for v_ in v]
+            params[k] = list(map(list, itertools.product(*v)))
+    return params
+
+
+class ParameterSampler:
+    """Generator on parameters sampled from given distributions.
+    Non-deterministic iterable over random candidate combinations for hyper-
+    parameter search. If all parameters are presented as a list,
+    sampling without replacement is performed. If at least one parameter
+    is given as a distribution, sampling with replacement is used.
+    It is highly recommended to use continuous distributions for continuous
+    parameters.
+    Parameters
+    ----------
+    param_distributions : dict
+        Dictionary with parameters names (`str`) as keys and distributions
+        or lists of parameters to try. Distributions must provide a ``rvs``
+        method for sampling (such as those from scipy.stats.distributions).
+        If a list is given, it is sampled uniformly.
+        If a list of dicts is given, first a dict is sampled uniformly, and
+        then a parameter is sampled using that dict as above.
+    n_iter : int
+        Number of parameter settings that are produced.
+    random_state : int, RandomState instance or None, default=None
+        Pseudo random number generator state used for random uniform sampling
+        from lists of possible values instead of scipy.stats distributions.
+        Pass an int for reproducible output across multiple
+        function calls.
+    Returns
+    -------
+    params : dict of str to any
+        **Yields** dictionaries mapping each estimator parameter to
+        as sampled value.
+    """
+
+    def __init__(self, param_distributions, n_iter, *, random_state=None):
+        if not isinstance(param_distributions, (Mapping, Iterable)):
+            raise TypeError(
+                "Parameter distribution is not a dict or a list ({!r})".format(
+                    param_distributions
+                )
+            )
+
+        if isinstance(param_distributions, Mapping):
+            # wrap dictionary in a singleton list to support either dict
+            # or list of dicts
+            param_distributions = [param_distributions]
+
+        for dist in param_distributions:
+            if not isinstance(dist, dict):
+                raise TypeError(
+                    "Parameter distribution is not a dict ({!r})".format(dist)
+                )
+            for key in dist:
+                if isinstance(dist[key], Iterable):
+                    if any(
+                            [
+                                not isinstance(view_param, Iterable)
+                                and not hasattr(view_param, "rvs")
+                                for view_param in dist[key]
+                            ]
+                    ):
+                        raise TypeError(
+                            "Parameter value for at least one view is not iterable "
+                            "or distribution (key={!r}, value={!r})".format(
+                                key, dist[key]
+                            )
+                        )
+                elif not hasattr(dist[key], "rvs"):
+                    raise TypeError(
+                        "Parameter value is not iterable "
+                        "or distribution (key={!r}, value={!r})".format(key, dist[key])
+                    )
+        self.n_iter = n_iter
+        self.random_state = random_state
+        self.param_distributions = param_distributions
+
+    def __iter__(self):
+        rng = check_random_state(self.random_state)
+        for _ in range(self.n_iter):
+            dist = rng.choice(self.param_distributions)
+            # Always sort the keys of a dictionary, for reproducibility
+            items = sorted(dist.items())
+            params = dict()
+            for k, v in items:
+                # if value is an iterable then either the elements are the distribution or each element is a distribution
+                # for each view.
+                if isinstance(v, Iterable):
+                    # if the parameter is shared across views then the list will just contain non-iterable values
+                    if not any(
+                            [
+                                (isinstance(v_, Iterable) and not isinstance(v_, str))
+                                for v_ in v
+                            ]
+                    ):
+                        params[k] = self.return_param(v)
+                    # if each element is a distribution for each view (i.e. it is a non-string Iterable) then call return_param for each view
+                    else:
+                        params[k] = [self.return_param(v_) for v_ in v]
+                # if value is not iterable then it is either a distribution or a value in which case call return param on it.
+                else:
+                    params[k] = self.return_param(v)
+            yield params
+
+    def return_param(self, v):
+        rng = check_random_state(self.random_state)
+        if hasattr(v, "rvs"):
+            param = v.rvs(random_state=rng)
+        elif isinstance(v, Iterable) and not isinstance(v, str):
+            param = v[rng.randint(len(v))]
+        else:
+            param = v
+        return param
+
+    def __len__(self):
+        """Number of points that will be sampled."""
+        return self.n_iter
+
+
+class BaseSearchCV(SKBaseSearchCV):
+    def __init__(
+            self,
+            estimator,
+            *,
+            scoring=None,
+            n_jobs=None,
+            refit=True,
+            cv=None,
+            verbose=0,
+            pre_dispatch="2*n_jobs",
+            error_score=np.nan,
+            return_train_score=True,
+    ):
+        super().__init__(
+            estimator=estimator,
+            scoring=scoring,
+            n_jobs=n_jobs,
+            refit=refit,
+            cv=cv,
+            verbose=verbose,
+            pre_dispatch=pre_dispatch,
+            error_score=error_score,
+            return_train_score=return_train_score,
+        )
+
+    def fit(self, Xs, y=None, *, groups=None, **fit_params):
+        """Run fit with all sets of parameters.
+        Parameters
+        ----------
+        Xs : array-like of shape (n_samples, n_features)
+            Training vector, where `n_samples` is the number of samples and
+            `n_features` is the number of features.
+        y : array-like of shape (n_samples, n_output) \
+            or (n_samples,), default=None
+            Target relative to X for classification or regression;
+            None for unsupervised learning.
+        groups : array-like of shape (n_samples,), default=None
+            Group labels for the samples used while splitting the dataset into
+            train/test set. Only used in conjunction with a "Group" :term:`cv`
+            instance (e.g., :class:`~sklearn.model_selection.GroupKFold`).
+        **fit_params : dict of str -> object
+            Parameters passed to the ``fit`` method of the estimator.
+        Returns
+        -------
+        self : object
+            Instance of fitted estimator.
+        """
+        estimator = self.estimator
+        refit_metric = "score"
+
+        if callable(self.scoring):
+            scorers = self.scoring
+        elif self.scoring is None or isinstance(self.scoring, str):
+            scorers = check_scoring(self.estimator, self.scoring)
+        else:
+            scorers = _check_multimetric_scoring(self.estimator, self.scoring)
+            self._check_refit_for_multimetric(scorers)
+            refit_metric = self.refit
+
+        Xs[0], y, groups = indexable(Xs[0], y, groups)
+        fit_params = _check_fit_params(Xs[0], fit_params)
+
+        cv_orig = check_cv(self.cv, y, classifier=is_classifier(estimator))
+        n_splits = cv_orig.get_n_splits(Xs[0], y, groups)
+
+        base_estimator = clone(self.estimator)
+
+        parallel = Parallel(n_jobs=self.n_jobs, pre_dispatch=self.pre_dispatch)
+
+        fit_and_score_kwargs = dict(
+            scorer=scorers,
+            fit_params=fit_params,
+            return_train_score=self.return_train_score,
+            return_n_test_samples=True,
+            return_times=True,
+            return_parameters=False,
+            error_score=self.error_score,
+            verbose=self.verbose,
+        )
+        results = {}
+        with parallel:
+            all_candidate_params = []
+            all_out = []
+            all_more_results = defaultdict(list)
+
+            def evaluate_candidates(candidate_params, cv=None, more_results=None):
+                cv = cv or cv_orig
+                candidate_params = list(candidate_params)
+                n_candidates = len(candidate_params)
+
+                if self.verbose > 0:
+                    print(
+                        "Fitting {0} folds for each of {1} candidates,"
+                        " totalling {2} fits".format(
+                            n_splits, n_candidates, n_candidates * n_splits
+                        )
+                    )
+
+                X_transformed, _, _, n_features = check_Xs(
+                    Xs, copy=True, return_dimensions=True
+                )
+                pipeline = Pipeline(
+                    [
+                        ("splitter", SimpleSplitter(n_features)),
+                        ("estimator", clone(base_estimator)),
+                    ]
+                )
+
+                out = parallel(
+                    delayed(_fit_and_score)(
+                        pipeline,
+                        np.hstack(Xs),
+                        y,
+                        train=train,
+                        test=test,
+                        parameters={
+                            f"estimator__{k}": v for k, v in parameters.items()
+                        },
+                        split_progress=(split_idx, n_splits),
+                        candidate_progress=(cand_idx, n_candidates),
+                        **fit_and_score_kwargs,
+                    )
+                    for (cand_idx, parameters), (split_idx, (train, test)) in product(
+                        enumerate(candidate_params),
+                        enumerate(cv.split(Xs[0], y, groups)),
+                    )
+                )
+
+                if len(out) < 1:
+                    raise ValueError(
+                        "No fits were performed. "
+                        "Was the CV iterator empty? "
+                        "Were there no candidates?"
+                    )
+                elif len(out) != n_candidates * n_splits:
+                    raise ValueError(
+                        "cv.split and cv.get_n_splits returned "
+                        "inconsistent results. Expected {} "
+                        "splits, got {}".format(n_splits, len(out) // n_candidates)
+                    )
+
+                # For callable self.scoring, the return type is only know after
+                # calling. If the return type is a dictionary, the error scores
+                # can now be inserted with the correct key. The type checking
+                # of out will be done in `_insert_error_scores`.
+                if callable(self.scoring):
+                    _insert_error_scores(out, self.error_score)
+
+                all_candidate_params.extend(candidate_params)
+                all_out.extend(out)
+
+                if more_results is not None:
+                    for key, value in more_results.items():
+                        all_more_results[key].extend(value)
+
+                nonlocal results
+                results = self._format_results(
+                    all_candidate_params, n_splits, all_out, all_more_results
+                )
+
+                return results
+
+            self._run_search(evaluate_candidates)
+
+            # multimetric is determined here because in the case of a callable
+            # self.scoring the return type is only known after calling
+            first_test_score = all_out[0]["test_scores"]
+            self.multimetric_ = isinstance(first_test_score, dict)
+
+            # check refit_metric now for a callabe scorer that is multimetric
+            if callable(self.scoring) and self.multimetric_:
+                self._check_refit_for_multimetric(first_test_score)
+                refit_metric = self.refit
+
+        # For multi-metric evaluation, store the best_index_, best_params_ and
+        # best_score_ iff refit is one of the scorer names
+        # In single metric evaluation, refit_metric is "score"
+        if self.refit or not self.multimetric_:
+            self.best_index_ = self._select_best_index(
+                self.refit, refit_metric, results
+            )
+            if not callable(self.refit):
+                # With a non-custom callable, we can select the best score
+                # based on the best index
+                self.best_score_ = results[f"mean_test_{refit_metric}"][
+                    self.best_index_
+                ]
+            self.best_params_ = results["params"][self.best_index_]
+
+        if self.refit:
+            # we clone again after setting params in case some
+            # of the params are estimators as well.
+            self.best_estimator_ = clone(
+                clone(base_estimator).set_params(**self.best_params_)
+            )
+            refit_start_time = time.time()
+            if y is not None:
+                self.best_estimator_.fit(Xs, y, **fit_params)
+            else:
+                self.best_estimator_.fit(Xs, **fit_params)
+            refit_end_time = time.time()
+            self.refit_time_ = refit_end_time - refit_start_time
+
+            if hasattr(self.best_estimator_, "feature_names_in_"):
+                self.feature_names_in_ = self.best_estimator_.feature_names_in_
+
+        # Store the only scorer not as a dict for single metric evaluation
+        self.scorer_ = scorers
+
+        self.cv_results_ = results
+        self.n_splits_ = n_splits
+        return self
+
+    @staticmethod
+    def _select_best_index(refit, refit_metric, results):
+        """Select index of the best combination of hyperparemeters."""
+        if callable(refit):
+            # If callable, refit is expected to return the index of the best
+            # parameter set.
+            best_index = refit(results)
+            if not isinstance(best_index, numbers.Integral):
+                raise TypeError("best_index_ returned is not an integer")
+            if best_index < 0 or best_index >= len(results["params"]):
+                raise IndexError("best_index_ index out of range")
+        else:
+            best_index = results[f"rank_test_{refit_metric}"].argmin()
+        return best_index
+
+
+class GridSearchCV(BaseSearchCV):
+    """Exhaustive search over specified parameter values for an estimator.
+    Important members are fit, predict.
+    GridSearchCV implements a "fit" and a "score" method.
+    It also implements "score_samples", "predict", "predict_proba",
+    "decision_function", "transform" and "inverse_transform" if they are
+    implemented in the estimator used.
+    The parameters of the estimator used to apply these methods are optimized
+    by cross-validated grid-search over a parameter grid.
+    Parameters
+    ----------
+    estimator : estimator object
+        This is assumed to implement the scikit-learn estimator interface.
+        Either estimator needs to provide a ``score`` function,
+        or ``scoring`` must be passed.
+    param_grid : dict or list of dictionaries
+        Dictionary with parameters names (`str`) as keys and lists of
+        parameter settings to try as values, or a list of such
+        dictionaries, in which case the grids spanned by each dictionary
+        in the list are explored. This enables searching over any sequence
+        of parameter settings.
+    scoring : str, callable, list, tuple or dict, default=None
+        Strategy to evaluate the performance of the cross-validated model on
+        the test set.
+        If `scoring` represents a single score, one can use:
+        - a single string (see :ref:`scoring_parameter`);
+        - a callable (see :ref:`scoring`) that returns a single value.
+        If `scoring` represents multiple scores, one can use:
+        - a list or tuple of unique strings;
+        - a callable returning a dictionary where the keys are the metric
+          names and the values are the metric scores;
+        - a dictionary with metric names as keys and callables a values.
+        See :ref:`multimetric_grid_search` for an example.
+    n_jobs : int, default=None
+        Number of jobs to run in parallel.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+    refit : bool, str, or callable, default=True
+        Refit an estimator using the best found parameters on the whole
+        dataset.
+        For multiple metric evaluation, this needs to be a `str` denoting the
+        scorer that would be used to find the best parameters for refitting
+        the estimator at the end.
+        Where there are considerations other than maximum score in
+        choosing a best estimator, ``refit`` can be set to a function which
+        returns the selected ``best_index_`` given ``cv_results_``. In that
+        case, the ``best_estimator_`` and ``best_params_`` will be set
+        according to the returned ``best_index_`` while the ``best_score_``
+        attribute will not be available.
+        The refitted estimator is made available at the ``best_estimator_``
+        attribute and permits using ``predict`` directly on this
+        ``GridSearchCV`` instance.
+        Also for multiple metric evaluation, the attributes ``best_index_``,
+        ``best_score_`` and ``best_params_`` will only be available if
+        ``refit`` is set and all of them will be determined w.r.t this specific
+        scorer.
+        See ``scoring`` parameter to know more about multiple metric
+        evaluation.
+    cv : int, cross-validation generator or an iterable, default=None
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+        - None, to use the default 5-fold cross validation,
+        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - :term:`CV splitter`,
+        - An iterable yielding (train, test) splits as arrays of indices.
+        For integer/None inputs, if the estimator is a classifier and ``y`` is
+        either binary or multiclass, :class:`StratifiedKFold` is used. In all
+        other cases, :class:`KFold` is used. These splitters are instantiated
+        with `shuffle=False` so the splits will be the same across calls.
+        Refer :ref:`User Guide <cross_validation>` for the various
+        cross-validation strategies that can be used here.
+    verbose : int
+        Controls the verbosity: the higher, the more messages.
+        - >1 : the computation time for each fold and parameter candidate is
+          displayed;
+        - >2 : the score is also displayed;
+        - >3 : the fold and candidate parameter indexes are also displayed
+          together with the starting time of the computation.
+    pre_dispatch : int, or str, default='2*n_jobs'
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+            - An int, giving the exact number of total jobs that are
+              spawned
+            - A str, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+    error_score : 'raise' or numeric, default=np.nan
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
+    return_train_score : bool, default=False
+        If ``False``, the ``cv_results_`` attribute will not include training
+        scores.
+        Computing training scores is used to get insights on how different
+        parameter settings impact the overfitting/underfitting trade-off.
+        However computing the scores on the training set can be computationally
+        expensive and is not strictly required to select the parameters that
+        yield the best generalization performance.
+    Attributes
+    ----------
+    cv_results_ : dict of numpy (masked) ndarrays
+        A dict with keys as column headers and values as columns, that can be
+        imported into a pandas ``DataFrame``.
+        For instance the below given table
+        +------------+-----------+------------+-----------------+---+---------+
+        |param_kernel|param_gamma|param_degree|split0_test_score|...|rank_t...|
+        +============+===========+============+=================+===+=========+
+        |  'poly'    |     --    |      2     |       0.80      |...|    2    |
+        +------------+-----------+------------+-----------------+---+---------+
+        |  'poly'    |     --    |      3     |       0.70      |...|    4    |
+        +------------+-----------+------------+-----------------+---+---------+
+        |  'rbf'     |     0.1   |     --     |       0.80      |...|    3    |
+        +------------+-----------+------------+-----------------+---+---------+
+        |  'rbf'     |     0.2   |     --     |       0.93      |...|    1    |
+        +------------+-----------+------------+-----------------+---+---------+
+        will be represented by a ``cv_results_`` dict of::
+            {
+            'param_kernel': masked_array(data = ['poly', 'poly', 'rbf', 'rbf'],
+                                         mask = [False False False False]...)
+            'param_gamma': masked_array(data = [-- -- 0.1 0.2],
+                                        mask = [ True  True False False]...),
+            'param_degree': masked_array(data = [2.0 3.0 -- --],
+                                         mask = [False False  True  True]...),
+            'split0_test_score'  : [0.80, 0.70, 0.80, 0.93],
+            'split1_test_score'  : [0.82, 0.50, 0.70, 0.78],
+            'mean_test_score'    : [0.81, 0.60, 0.75, 0.85],
+            'std_test_score'     : [0.01, 0.10, 0.05, 0.08],
+            'rank_test_score'    : [2, 4, 3, 1],
+            'split0_train_score' : [0.80, 0.92, 0.70, 0.93],
+            'split1_train_score' : [0.82, 0.55, 0.70, 0.87],
+            'mean_train_score'   : [0.81, 0.74, 0.70, 0.90],
+            'std_train_score'    : [0.01, 0.19, 0.00, 0.03],
+            'mean_fit_time'      : [0.73, 0.63, 0.43, 0.49],
+            'std_fit_time'       : [0.01, 0.02, 0.01, 0.01],
+            'mean_score_time'    : [0.01, 0.06, 0.04, 0.04],
+            'std_score_time'     : [0.00, 0.00, 0.00, 0.01],
+            'params'             : [{'kernel': 'poly', 'degree': 2}, ...],
+            }
+        NOTE
+        The key ``'params'`` is used to store a list of parameter
+        settings dicts for all the parameter candidates.
+        The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
+        ``std_score_time`` are all in seconds.
+        For multi-metric evaluation, the scores for all the scorers are
+        available in the ``cv_results_`` dict at the keys ending with that
+        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
+        above. ('split0_test_precision', 'mean_train_precision' etc.)
+    best_estimator_ : estimator
+        Estimator that was chosen by the search, i.e. estimator
+        which gave highest score (or smallest loss if specified)
+        on the left out data. Not available if ``refit=False``.
+        See ``refit`` parameter for more information on allowed values.
+    best_score_ : float
+        Mean cross-validated score of the best_estimator
+        For multi-metric evaluation, this is present only if ``refit`` is
+        specified.
+        This attribute is not available if ``refit`` is a function.
+    best_params_ : dict
+        Parameter setting that gave the best results on the hold out data.
+        For multi-metric evaluation, this is present only if ``refit`` is
+        specified.
+    best_index_ : int
+        The index (of the ``cv_results_`` arrays) which corresponds to the best
+        candidate parameter setting.
+        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
+        the parameter setting for the best model, that gives the highest
+        mean score (``search.best_score_``).
+        For multi-metric evaluation, this is present only if ``refit`` is
+        specified.
+    scorer_ : function or a dict
+        Scorer function used on the held out data to choose the best
+        parameters for the model.
+        For multi-metric evaluation, this attribute holds the validated
+        ``scoring`` dict which maps the scorer key to the scorer callable.
+    n_splits_ : int
+        The number of cross-validation splits (folds/iterations).
+    refit_time_ : float
+        Seconds used for refitting the best model on the whole dataset.
+        This is present only if ``refit`` is not False.
+        .. versionadded:: 0.20
+    multimetric_ : bool
+        Whether or not the scorers compute several metrics.
+    classes_ : ndarray of shape (n_classes,)
+        The classes labels. This is present only if ``refit`` is specified and
+        the underlying estimator is a classifier.
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes
+        `n_features_in_` when fit.
+        .. versionadded:: 0.24
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes
+        `feature_names_in_` when fit.
+        .. versionadded:: 1.0
+    Notes
+    -----
+    The parameters selected are those that maximize the score of the left out
+    data, unless an explicit score is passed in which case it is used instead.
+    If `n_jobs` was set to a value higher than one, the data is copied for each
+    point in the grid (and not `n_jobs` times). This is done for efficiency
+    reasons if individual jobs take very little time, but may raise errors if
+    the dataset is large and not enough memory is available.  A workaround in
+    this case is to set `pre_dispatch`. Then, the memory is copied only
+    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    n_jobs`.
+
+    """
+
+    _required_parameters = ["estimator", "param_grid"]
+
+    def __init__(
+            self,
+            estimator,
+            param_grid,
+            *,
+            scoring=None,
+            n_jobs=None,
+            refit=True,
+            cv=None,
+            verbose=0,
+            pre_dispatch="2*n_jobs",
+            error_score=np.nan,
+            return_train_score=False,
+    ):
+        super().__init__(
+            estimator=estimator,
+            scoring=scoring,
+            n_jobs=n_jobs,
+            refit=refit,
+            cv=cv,
+            verbose=verbose,
+            pre_dispatch=pre_dispatch,
+            error_score=error_score,
+            return_train_score=return_train_score,
+        )
+        self.param_grid = param2grid(param_grid)
+        _check_param_grid(param_grid)
+
+    def _run_search(self, evaluate_candidates):
+        """Search all candidates in param_grid"""
+        evaluate_candidates(ParameterGrid(self.param_grid))
+
+
+class RandomizedSearchCV(BaseSearchCV):
+    """Randomized search on hyper parameters.
+    RandomizedSearchCV implements a "fit" and a "score" method.
+    It also implements "score_samples", "predict", "predict_proba",
+    "decision_function", "transform" and "inverse_transform" if they are
+    implemented in the estimator used.
+    The parameters of the estimator used to apply these methods are optimized
+    by cross-validated search over parameter settings.
+    In contrast to GridSearchCV, not all parameter values are tried out, but
+    rather a fixed number of parameter settings is sampled from the specified
+    distributions. The number of parameter settings that are tried is
+    given by n_iter.
+    If all parameters are presented as a list,
+    sampling without replacement is performed. If at least one parameter
+    is given as a distribution, sampling with replacement is used.
+    It is highly recommended to use continuous distributions for continuous
+    parameters.
+
+    Parameters
+    ----------
+    estimator : estimator object.
+        A object of that type is instantiated for each grid point.
+        This is assumed to implement the scikit-learn estimator interface.
+        Either estimator needs to provide a ``score`` function,
+        or ``scoring`` must be passed.
+    param_distributions : dict or list of dicts
+        Dictionary with parameters names (`str`) as keys and distributions
+        or lists of parameters to try. Distributions must provide a ``rvs``
+        method for sampling (such as those from scipy.stats.distributions).
+        If a list is given, it is sampled uniformly.
+        If a list of dicts is given, first a dict is sampled uniformly, and
+        then a parameter is sampled using that dict as above.
+    n_iter : int, default=10
+        Number of parameter settings that are sampled. n_iter trades
+        off runtime vs quality of the solution.
+    scoring : str, callable, list, tuple or dict, default=None
+        Strategy to evaluate the performance of the cross-validated model on
+        the test set.
+        If `scoring` represents a single score, one can use:
+        - a single string (see :ref:`scoring_parameter`);
+        - a callable (see :ref:`scoring`) that returns a single value.
+        If `scoring` represents multiple scores, one can use:
+        - a list or tuple of unique strings;
+        - a callable returning a dictionary where the keys are the metric
+          names and the values are the metric scores;
+        - a dictionary with metric names as keys and callables a values.
+        See :ref:`multimetric_grid_search` for an example.
+        If None, the estimator's score method is used.
+    n_jobs : int, default=None
+        Number of jobs to run in parallel.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
+        for more details.
+    refit : bool, str, or callable, default=True
+        Refit an estimator using the best found parameters on the whole
+        dataset.
+        For multiple metric evaluation, this needs to be a `str` denoting the
+        scorer that would be used to find the best parameters for refitting
+        the estimator at the end.
+        Where there are considerations other than maximum score in
+        choosing a best estimator, ``refit`` can be set to a function which
+        returns the selected ``best_index_`` given the ``cv_results``. In that
+        case, the ``best_estimator_`` and ``best_params_`` will be set
+        according to the returned ``best_index_`` while the ``best_score_``
+        attribute will not be available.
+        The refitted estimator is made available at the ``best_estimator_``
+        attribute and permits using ``predict`` directly on this
+        ``RandomizedSearchCV`` instance.
+        Also for multiple metric evaluation, the attributes ``best_index_``,
+        ``best_score_`` and ``best_params_`` will only be available if
+        ``refit`` is set and all of them will be determined w.r.t this specific
+        scorer.
+        See ``scoring`` parameter to know more about multiple metric
+        evaluation.
+    cv : int, cross-validation generator or an iterable, default=None
+        Determines the cross-validation splitting strategy.
+        Possible inputs for cv are:
+        - None, to use the default 5-fold cross validation,
+        - integer, to specify the number of folds in a `(Stratified)KFold`,
+        - :term:`CV splitter`,
+        - An iterable yielding (train, test) splits as arrays of indices.
+        For integer/None inputs, if the estimator is a classifier and ``y`` is
+        either binary or multiclass, :class:`StratifiedKFold` is used. In all
+        other cases, :class:`KFold` is used. These splitters are instantiated
+        with `shuffle=False` so the splits will be the same across calls.
+        Refer :ref:`User Guide <cross_validation>` for the various
+        cross-validation strategies that can be used here.
+    verbose : int
+        Controls the verbosity: the higher, the more messages.
+    pre_dispatch : int, or str, default='2*n_jobs'
+        Controls the number of jobs that get dispatched during parallel
+        execution. Reducing this number can be useful to avoid an
+        explosion of memory consumption when more jobs get dispatched
+        than CPUs can process. This parameter can be:
+            - None, in which case all the jobs are immediately
+              created and spawned. Use this for lightweight and
+              fast-running jobs, to avoid delays due to on-demand
+              spawning of the jobs
+            - An int, giving the exact number of total jobs that are
+              spawned
+            - A str, giving an expression as a function of n_jobs,
+              as in '2*n_jobs'
+    random_state : int, RandomState instance or None, default=None
+        Pseudo random number generator state used for random uniform sampling
+        from lists of possible values instead of scipy.stats distributions.
+        Pass an int for reproducible output across multiple
+        function calls.
+    error_score : 'raise' or numeric, default=np.nan
+        Value to assign to the score if an error occurs in estimator fitting.
+        If set to 'raise', the error is raised. If a numeric value is given,
+        FitFailedWarning is raised. This parameter does not affect the refit
+        step, which will always raise the error.
+    return_train_score : bool, default=False
+        If ``False``, the ``cv_results_`` attribute will not include training
+        scores.
+        Computing training scores is used to get insights on how different
+        parameter settings impact the overfitting/underfitting trade-off.
+        However computing the scores on the training set can be computationally
+        expensive and is not strictly required to select the parameters that
+        yield the best generalization performance.
+    Attributes
+    ----------
+    cv_results_ : dict of numpy (masked) ndarrays
+        A dict with keys as column headers and values as columns, that can be
+        imported into a pandas ``DataFrame``.
+        For instance the below given table
+        +--------------+-------------+-------------------+---+---------------+
+        | param_kernel | param_gamma | split0_test_score |...|rank_test_score|
+        +==============+=============+===================+===+===============+
+        |    'rbf'     |     0.1     |       0.80        |...|       1       |
+        +--------------+-------------+-------------------+---+---------------+
+        |    'rbf'     |     0.2     |       0.84        |...|       3       |
+        +--------------+-------------+-------------------+---+---------------+
+        |    'rbf'     |     0.3     |       0.70        |...|       2       |
+        +--------------+-------------+-------------------+---+---------------+
+        will be represented by a ``cv_results_`` dict of::
+            {
+            'param_kernel' : masked_array(data = ['rbf', 'rbf', 'rbf'],
+                                          mask = False),
+            'param_gamma'  : masked_array(data = [0.1 0.2 0.3], mask = False),
+            'split0_test_score'  : [0.80, 0.84, 0.70],
+            'split1_test_score'  : [0.82, 0.50, 0.70],
+            'mean_test_score'    : [0.81, 0.67, 0.70],
+            'std_test_score'     : [0.01, 0.24, 0.00],
+            'rank_test_score'    : [1, 3, 2],
+            'split0_train_score' : [0.80, 0.92, 0.70],
+            'split1_train_score' : [0.82, 0.55, 0.70],
+            'mean_train_score'   : [0.81, 0.74, 0.70],
+            'std_train_score'    : [0.01, 0.19, 0.00],
+            'mean_fit_time'      : [0.73, 0.63, 0.43],
+            'std_fit_time'       : [0.01, 0.02, 0.01],
+            'mean_score_time'    : [0.01, 0.06, 0.04],
+            'std_score_time'     : [0.00, 0.00, 0.00],
+            'params'             : [{'kernel' : 'rbf', 'gamma' : 0.1}, ...],
+            }
+        NOTE
+        The key ``'params'`` is used to store a list of parameter
+        settings dicts for all the parameter candidates.
+        The ``mean_fit_time``, ``std_fit_time``, ``mean_score_time`` and
+        ``std_score_time`` are all in seconds.
+        For multi-metric evaluation, the scores for all the scorers are
+        available in the ``cv_results_`` dict at the keys ending with that
+        scorer's name (``'_<scorer_name>'``) instead of ``'_score'`` shown
+        above. ('split0_test_precision', 'mean_train_precision' etc.)
+    best_estimator_ : estimator
+        Estimator that was chosen by the search, i.e. estimator
+        which gave highest score (or smallest loss if specified)
+        on the left out data. Not available if ``refit=False``.
+        For multi-metric evaluation, this attribute is present only if
+        ``refit`` is specified.
+        See ``refit`` parameter for more information on allowed values.
+    best_score_ : float
+        Mean cross-validated score of the best_estimator.
+        For multi-metric evaluation, this is not available if ``refit`` is
+        ``False``. See ``refit`` parameter for more information.
+        This attribute is not available if ``refit`` is a function.
+    best_params_ : dict
+        Parameter setting that gave the best results on the hold out data.
+        For multi-metric evaluation, this is not available if ``refit`` is
+        ``False``. See ``refit`` parameter for more information.
+    best_index_ : int
+        The index (of the ``cv_results_`` arrays) which corresponds to the best
+        candidate parameter setting.
+        The dict at ``search.cv_results_['params'][search.best_index_]`` gives
+        the parameter setting for the best model, that gives the highest
+        mean score (``search.best_score_``).
+        For multi-metric evaluation, this is not available if ``refit`` is
+        ``False``. See ``refit`` parameter for more information.
+    scorer_ : function or a dict
+        Scorer function used on the held out data to choose the best
+        parameters for the model.
+        For multi-metric evaluation, this attribute holds the validated
+        ``scoring`` dict which maps the scorer key to the scorer callable.
+    n_splits_ : int
+        The number of cross-validation splits (folds/iterations).
+    refit_time_ : float
+        Seconds used for refitting the best model on the whole dataset.
+        This is present only if ``refit`` is not False.
+        .. versionadded:: 0.20
+    multimetric_ : bool
+        Whether or not the scorers compute several metrics.
+    classes_ : ndarray of shape (n_classes,)
+        The classes labels. This is present only if ``refit`` is specified and
+        the underlying estimator is a classifier.
+    n_features_in_ : int
+        Number of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes
+        `n_features_in_` when fit.
+        .. versionadded:: 0.24
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Only defined if
+        `best_estimator_` is defined (see the documentation for the `refit`
+        parameter for more details) and that `best_estimator_` exposes
+        `feature_names_in_` when fit.
+        .. versionadded:: 1.0
+    Notes
+    -----
+    The parameters selected are those that maximize the score of the held-out
+    data, according to the scoring parameter.
+    If `n_jobs` was set to a value higher than one, the data is copied for each
+    parameter setting(and not `n_jobs` times). This is done for efficiency
+    reasons if individual jobs take very little time, but may raise errors if
+    the dataset is large and not enough memory is available.  A workaround in
+    this case is to set `pre_dispatch`. Then, the memory is copied only
+    `pre_dispatch` many times. A reasonable value for `pre_dispatch` is `2 *
+    n_jobs`.
+    """
+
+    _required_parameters = ["estimator", "param_distributions"]
+
+    def __init__(
+            self,
+            estimator,
+            param_distributions,
+            *,
+            n_iter=10,
+            scoring=None,
+            n_jobs=None,
+            refit=True,
+            cv=None,
+            verbose=0,
+            pre_dispatch="2*n_jobs",
+            random_state=None,
+            error_score=np.nan,
+            return_train_score=False,
+    ):
+        self.param_distributions = param_distributions
+        self.n_iter = n_iter
+        self.random_state = random_state
+        super().__init__(
+            estimator=estimator,
+            scoring=scoring,
+            n_jobs=n_jobs,
+            refit=refit,
+            cv=cv,
+            verbose=verbose,
+            pre_dispatch=pre_dispatch,
+            error_score=error_score,
+            return_train_score=return_train_score,
+        )
+
+    def _run_search(self, evaluate_candidates):
+        """Search n_iter candidates from param_distributions"""
+        evaluate_candidates(
+            ParameterSampler(
+                self.param_distributions, self.n_iter, random_state=self.random_state
+            )
+        )

--- a/mvlearn/model_selection/_search.py
+++ b/mvlearn/model_selection/_search.py
@@ -41,16 +41,14 @@ def param2grid(params):
 
     Examples
     ---------
-    >>> params = {
-    >>>     'regs': [[1, 2], [3, 4]],
-    >>> }
+    >>> params = {'regs': [[1, 2], [3, 4]]}
     >>> param2grid(params)
-    >>> [[1,3], [1,4], [2,3], [2,4]]
+    [[1,3], [1,4], [2,3], [2,4]]
     """
     for k, v in params.items():
         if any([isinstance(v_, list) for v_ in v]):
-            #itertools expects all lists to perform product
-            v=[[v_] if not isinstance(v_, list) else v_ for v_ in v]
+            # itertools expects all lists to perform product
+            v = [[v_] if not isinstance(v_, list) else v_ for v_ in v]
             params[k] = list(map(list, itertools.product(*v)))
     return params
 
@@ -107,11 +105,11 @@ class ParameterSampler:
             for key in dist:
                 if isinstance(dist[key], Iterable):
                     if any(
-                            [
-                                not isinstance(view_param, Iterable)
-                                and not hasattr(view_param, "rvs")
-                                for view_param in dist[key]
-                            ]
+                        [
+                            not isinstance(view_param, Iterable)
+                            and not hasattr(view_param, "rvs")
+                            for view_param in dist[key]
+                        ]
                     ):
                         raise TypeError(
                             "Parameter value for at least one view is not iterable "
@@ -141,10 +139,10 @@ class ParameterSampler:
                 if isinstance(v, Iterable):
                     # if the parameter is shared across views then the list will just contain non-iterable values
                     if not any(
-                            [
-                                (isinstance(v_, Iterable) and not isinstance(v_, str))
-                                for v_ in v
-                            ]
+                        [
+                            (isinstance(v_, Iterable) and not isinstance(v_, str))
+                            for v_ in v
+                        ]
                     ):
                         params[k] = self.return_param(v)
                     # if each element is a distribution for each view (i.e. it is a non-string Iterable) then call return_param for each view
@@ -172,17 +170,17 @@ class ParameterSampler:
 
 class BaseSearchCV(SKBaseSearchCV):
     def __init__(
-            self,
-            estimator,
-            *,
-            scoring=None,
-            n_jobs=None,
-            refit=True,
-            cv=None,
-            verbose=0,
-            pre_dispatch="2*n_jobs",
-            error_score=np.nan,
-            return_train_score=True,
+        self,
+        estimator,
+        *,
+        scoring=None,
+        n_jobs=None,
+        refit=True,
+        cv=None,
+        verbose=0,
+        pre_dispatch="2*n_jobs",
+        error_score=np.nan,
+        return_train_score=True,
     ):
         super().__init__(
             estimator=estimator,
@@ -432,12 +430,10 @@ class GridSearchCV(BaseSearchCV):
         - a callable returning a dictionary where the keys are the metric
           names and the values are the metric scores;
         - a dictionary with metric names as keys and callables a values.
-        See :ref:`multimetric_grid_search` for an example.
     n_jobs : int, default=None
         Number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        ``-1`` means using all processors.
     refit : bool, str, or callable, default=True
         Refit an estimator using the best found parameters on the whole
         dataset.
@@ -601,6 +597,22 @@ class GridSearchCV(BaseSearchCV):
         `best_estimator_` is defined (see the documentation for the `refit`
         parameter for more details) and that `best_estimator_` exposes
         `feature_names_in_` when fit.
+
+    Examples
+    ---------
+    >>> from mvlearn.model_selection import GridSearchCV
+    >>> from mvlearn.embed import MCCA
+    >>> X1 = [[0, 0, 1], [1, 0, 0], [2, 2, 2], [3, 5, 4]]
+    >>> X2 = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
+    >>> X3 = [[0, 1, 0], [1, 9, 0], [4, 3, 3,], [12, 8, 10]]
+    >>> model = MCCA()
+    >>> params = {'regs': [[0.1, 0.2], [0.3, 0.4], 0.1]}
+    >>> def scorer(estimator, X):
+    ...    scores = estimator.score(X)
+    ...    return np.mean(scores)
+    >>> GridSearchCV(model,param_grid=params, cv=3, scoring=scorer).fit([X1,X2,X3]).best_estimator_
+    MCCA(regs=[0.1, 0.3, 0.1])
+
     Notes
     -----
     The parameters selected are those that maximize the score of the left out
@@ -618,18 +630,18 @@ class GridSearchCV(BaseSearchCV):
     _required_parameters = ["estimator", "param_grid"]
 
     def __init__(
-            self,
-            estimator,
-            param_grid,
-            *,
-            scoring=None,
-            n_jobs=None,
-            refit=True,
-            cv=None,
-            verbose=0,
-            pre_dispatch="2*n_jobs",
-            error_score=np.nan,
-            return_train_score=False,
+        self,
+        estimator,
+        param_grid,
+        *,
+        scoring=None,
+        n_jobs=None,
+        refit=True,
+        cv=None,
+        verbose=0,
+        pre_dispatch="2*n_jobs",
+        error_score=np.nan,
+        return_train_score=False,
     ):
         super().__init__(
             estimator=estimator,
@@ -696,13 +708,11 @@ class RandomizedSearchCV(BaseSearchCV):
         - a callable returning a dictionary where the keys are the metric
           names and the values are the metric scores;
         - a dictionary with metric names as keys and callables a values.
-        See :ref:`multimetric_grid_search` for an example.
         If None, the estimator's score method is used.
     n_jobs : int, default=None
         Number of jobs to run in parallel.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
-        for more details.
+        ``-1`` means using all processors.
     refit : bool, str, or callable, default=True
         Refit an estimator using the best found parameters on the whole
         dataset.
@@ -863,6 +873,23 @@ class RandomizedSearchCV(BaseSearchCV):
         `best_estimator_` is defined (see the documentation for the `refit`
         parameter for more details) and that `best_estimator_` exposes
         `feature_names_in_` when fit.
+
+    Examples
+    ---------
+    >>> from mvlearn.model_selection import RandomizedSearchCV
+    >>> from mvlearn.embed import MCCA
+    >>> from sklearn.utils.fixes import loguniform
+    >>> X1 = [[0, 0, 1], [1, 0, 0], [2, 2, 2], [3, 5, 4]]
+    >>> X2 = [[0.1, -0.2], [0.9, 1.1], [6.2, 5.9], [11.9, 12.3]]
+    >>> X3 = [[0, 1, 0], [1, 9, 0], [4, 3, 3,], [12, 8, 10]]
+    >>> model = MCCA()
+    >>> params = {'regs': [loguniform(1e-4, 1e0), loguniform(1e-4, 1e0), [0.1]]}
+    >>> def scorer(estimator, X):
+    ...    scores = estimator.score(X)
+    ...    return np.mean(scores)
+    >>> RandomizedSearchCV(model,param_distributions=params, cv=3, scoring=scorer,n_iter=10).fit([X1,X2,X3]).n_iter
+    10
+
     Notes
     -----
     The parameters selected are those that maximize the score of the held-out
@@ -879,20 +906,20 @@ class RandomizedSearchCV(BaseSearchCV):
     _required_parameters = ["estimator", "param_distributions"]
 
     def __init__(
-            self,
-            estimator,
-            param_distributions,
-            *,
-            n_iter=10,
-            scoring=None,
-            n_jobs=None,
-            refit=True,
-            cv=None,
-            verbose=0,
-            pre_dispatch="2*n_jobs",
-            random_state=None,
-            error_score=np.nan,
-            return_train_score=False,
+        self,
+        estimator,
+        param_distributions,
+        *,
+        n_iter=10,
+        scoring=None,
+        n_jobs=None,
+        refit=True,
+        cv=None,
+        verbose=0,
+        pre_dispatch="2*n_jobs",
+        random_state=None,
+        error_score=np.nan,
+        return_train_score=False,
     ):
         self.param_distributions = param_distributions
         self.n_iter = n_iter

--- a/tests/model_selection/test_validation.py
+++ b/tests/model_selection/test_validation.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.model_selection import cross_validate as sk_cross_validate
 from sklearn.pipeline import Pipeline
 from sklearn.linear_model import LogisticRegression
+from sklearn.utils.fixes import loguniform
 
 from mvlearn.model_selection import cross_validate
 from mvlearn.compose import ConcatMerger
@@ -40,8 +41,23 @@ def test_gridsearchcv():
         scores = estimator.score(X)
         return np.mean(scores)
 
-    cv_model = GridSearchCV(model, cv=5, param_grid=param_grid, scoring=scorer, n_jobs=1).fit(Xs)
+    cv_model = GridSearchCV(model, cv=5, param_grid=param_grid, scoring=scorer).fit(Xs)
 
 
-if __name__ == '__main__':
-    test_gridsearchcv()
+def test_randomizedsearchcv():
+    n_samples = 100
+    n_features = [2, 3, 4]
+    n_iter_search=10
+    rng = np.random.RandomState(0)
+    Xs = [rng.randn(n_samples, n_feature) for n_feature in n_features]
+    param_dists = {
+        'regs': [loguniform(1e-4, 1e0), loguniform(1e-4, 1e0), [0.1]],
+    }
+    model = MCCA()
+
+    def scorer(estimator, X, y):
+        scores = estimator.score(X)
+        return np.mean(scores)
+
+    cv_model = RandomizedSearchCV(model, cv=5, param_distributions=param_dists, scoring=scorer,n_iter=n_iter_search).fit(Xs)
+

--- a/tests/model_selection/test_validation.py
+++ b/tests/model_selection/test_validation.py
@@ -6,6 +6,8 @@ from sklearn.linear_model import LogisticRegression
 
 from mvlearn.model_selection import cross_validate
 from mvlearn.compose import ConcatMerger
+from mvlearn.model_selection._search import GridSearchCV, RandomizedSearchCV
+from mvlearn.embed import MCCA
 
 
 def test_cross_validate():
@@ -22,3 +24,24 @@ def test_cross_validate():
     mvscores = cross_validate(mvpipe, Xs, y)
     scores = sk_cross_validate(estimator, X, y)
     assert (scores['test_score'] == mvscores['test_score']).all()
+
+
+def test_gridsearchcv():
+    n_samples = 100
+    n_features = [2, 3, 4]
+    rng = np.random.RandomState(0)
+    Xs = [rng.randn(n_samples, n_feature) for n_feature in n_features]
+    param_grid = {
+        'regs': [[0.5, 0.4, 0.3], [1, 2, 3], 0.1],
+    }
+    model = MCCA()
+
+    def scorer(estimator, X, y):
+        scores = estimator.score(X)
+        return np.mean(scores)
+
+    cv_model = GridSearchCV(model, cv=5, param_grid=param_grid, scoring=scorer, n_jobs=1).fit(Xs)
+
+
+if __name__ == '__main__':
+    test_gridsearchcv()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/mvlearn/mvlearn/blob/main/CONTRIBUTING.md#pull-request-checklist
-->

#### What does this implement/fix? Explain your changes.
Adds some classes that wrap the scikit-learn BaseSearchCV classes and allow hyperparameter tuning in the same style using gridsearch and randomized search with cv

#### Any other comments?
Basically the barrier to using GridSearchCV and RandomizedSearchCV out of the box is that we sometimes have different values for the same parameter for different views as well as the similar problem to cross_validate() where we need to put in a splitter.

What I have done is to edit the fit() method in the scikit BaseSearchCV class and then made GridSearchCV and RandomizedSearchCV inherit the edited class with its new fit method.

On the parameter inputs side I have added a small utility function param2grid which essentially converts parameter grids containing multiple values for each view into a scikit friendly form. I think this cleans up the input from a user point of view as they can do something like:

`grid={'parameter': [[view 1 grid][view 2 grid]]}`

as opposed to

`grid={'parameter' : [list of all combinations of view 1 and view 2 grids]}`

I have also rejigged the scikit parameter sampler slightly to solve similar problems.

#### Noting Urgently!
I would like to add in the appropriate references to original code as large parts are exactly the same as scikit-learn. Didn't expect this pull request to go to the main repo expected it just to my fork!
