### PR TITLE
Fix CircleCI pipline: issue #307

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
               echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
               if [[ $(cat merge.txt) != "" ]]; then
                 echo "Merging $(cat merge.txt)";
-                git remote add upstream git://github.com/mvlearn/mvlearn.git;
+                git remote add upstream https://github.com/mvlearn/mvlearn.git;
                 git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
                 git fetch upstream main;
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
         - run:
             name: Fix libgcc_s.so.1 pthread_cancel bug
             command: |
+              sudo apt-get update
               sudo apt-get install qt5-default
 
         - run:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,7 +140,7 @@ htmlhelp_basename = "mvlearndoc"
 
 def setup(app):
     # to hide/show the prompt in code examples:
-    app.add_javascript("js/copybutton.js")
+    app.add_js_file("js/copybutton.js")
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx==4.2.0
-sphinx_rtd_theme==0.4.2
-ipython==7.16.3
-ipykernel==5.1.0
-numpydoc==0.7
+sphinx>=4.2.0
+sphinx_rtd_theme>=1.0.0
+ipython>=7.4
+ipykernel>=5.1.0
+numpydoc>=1.1.0
 recommonmark==0.5.0
 sphinx-gallery

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.8.5
+sphinx==4.2.0
 sphinx_rtd_theme==0.4.2
 ipython==7.16.3
 ipykernel==5.1.0


### PR DESCRIPTION
Fixes Issue #307 by switching git:// to https://. the former is no longer supported ([see here](https://github.blog/2021-09-01-improving-git-protocol-security-github/)).