### PR TITLE
CTClassifier fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ jobs:
               - data-cache-0
               - pip-cache
 
-        - run:
-            name: Spin up Xvfb
-            command: |
-              which Xvfb
+        # - run:
+        #     name: Spin up Xvfb
+        #     command: |
+        #       which Xvfb
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
         - run:
             name: Spin up Xvfb
             command: |
-              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,14 @@
 # Tagging a commit with [circle front] will build the front page and perform test-doc.
 # Tagging a commit with [circle full] will build everything.
 version: 2.1
+orbs:
+  python: circleci/python@2.1.1
 jobs:
     build_docs:
-      docker:
-        - image: cimg/python:3.18.15
+      executor:
+        name: python/default
+        # use Python 3.8
+        tag: '3.8'
       steps:
         - checkout
         - run:
@@ -88,8 +92,10 @@ jobs:
               - html
 
     deploy:
-      docker:
-        - image: cimg/python:3.18.15
+      executor:
+        name: python/default
+        # use Python 3.8
+        tag: '3.8'
       steps:
         - attach_workspace:
             at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ jobs:
             name: Spin up Xvfb
             command: |
               which Xvfb
-              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,11 @@ jobs:
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019
-        - run:
-            name: Fix libgcc_s.so.1 pthread_cancel bug
-            command: |
-              sudo apt-get update
-              sudo apt-get install qt5-default
+        # - run:
+        #     name: Fix libgcc_s.so.1 pthread_cancel bug
+        #     command: |
+        #       sudo apt-get update
+        #       sudo apt-get install qt5-default
 
         - run:
             name: Get Python running

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ jobs:
         - run:
             name: Spin up Xvfb
             command: |
-              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+              which Xvfb
+              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
 
         # https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
         # https://github.com/golemfactory/golem/issues/1019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # Tagging a commit with [circle front] will build the front page and perform test-doc.
 # Tagging a commit with [circle full] will build everything.
-version: 2
+version: 2.1
 jobs:
     build_docs:
       docker:
@@ -130,7 +130,7 @@ jobs:
               fi
 
 workflows:
-  version: 2
+  version: 2.1
 
   default:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
     build_docs:
       docker:
-        - image: cimg/python
+        - image: cimg/python:3.18.15
       steps:
         - checkout
         - run:
@@ -89,7 +89,7 @@ jobs:
 
     deploy:
       docker:
-        - image: cimg/python
+        - image: cimg/python:3.18.15
       steps:
         - attach_workspace:
             at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
     build_docs:
       docker:
-        - image: circleci/python:3.7-stretch
+        - image: cimg/python
       steps:
         - checkout
         - run:
@@ -89,7 +89,7 @@ jobs:
 
     deploy:
       docker:
-        - image: circleci/python:3.6-jessie
+        - image: cimg/python
       steps:
         - attach_workspace:
             at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
         - run:
             name: Get Python running
             command: |
+              sudo apt-get update
               sudo apt-get install pandoc
               python -m pip install --user --upgrade --progress-bar off pip
               python -m pip install --user --upgrade --progress-bar off -r requirements/base.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python_version: [3.6, 3.7, 3.8]
+        python_version: [3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{matrix.python_version}}

--- a/examples/cluster/mv_spherical_paper_validation_noinclude.py
+++ b/examples/cluster/mv_spherical_paper_validation_noinclude.py
@@ -118,7 +118,7 @@ def compute_entropy(partitions, labels, k, num_classes):
         for cl in range(num_classes):
             prop = np.sum(labs == cl) * 1.0 / part_size
             ent = 0
-            if(prop != 0):
+            if (prop != 0):
                 ent = - prop * np.log2(prop)
             part_entropy += ent
         part_entropy = part_entropy * part_size / num_examples

--- a/examples/semi_supervised/cotraining_classification_simulatedperformance_noinclude.py
+++ b/examples/semi_supervised/cotraining_classification_simulatedperformance_noinclude.py
@@ -313,8 +313,9 @@ for count, iters in enumerate(N_iters):
     for seed in range(randomizations):
 
         # Create Data
-        View1_train, View2_train, labels_train, labels_train_full, View1_test, \
-            View2_test, labels_test = create_data(seed, 1, .2, .2, N_per_class)
+        View1_train, View2_train, labels_train, labels_train_full, \
+            View1_test, View2_test, labels_test = create_data(
+                seed, 1, .2, .2, N_per_class)
         View2_train = View1_train.copy()
         View2_test = View1_test.copy()
 
@@ -829,8 +830,8 @@ for count, iters in enumerate(N_iters):
 
         # Create Data
         View1_train, View2_train, labels_train, labels_train_full, \
-        View1_test, View2_test, labels_test = create_data(
-            seed, 0, .2, .2, N_per_class, class2_mean_center)
+            View1_test, View2_test, labels_test = create_data(
+                seed, 0, .2, .2, N_per_class, class2_mean_center)
 
         # randomly remove some labels
         np.random.seed(11)

--- a/examples/semi_supervised/cotraining_classification_simulatedperformance_noinclude.py
+++ b/examples/semi_supervised/cotraining_classification_simulatedperformance_noinclude.py
@@ -74,7 +74,7 @@ def create_data(seed, class2_mean_center, view1_var, view2_var,
     labels_train = labels_train_full.copy()
     labels_test = labels_test_full.copy()
 
-    return View1_train, View2_train, labels_train, labels_train.copy(),\
+    return View1_train, View2_train, labels_train, labels_train.copy(), \
         View1_test, View2_test, labels_test
 
 ###############################################################################
@@ -221,8 +221,9 @@ for count, iters in enumerate(N_iters):
 
     for seed in range(randomizations):
 
-        View1_train, View2_train, labels_train, labels_train_full, View1_test,\
-            View2_test, labels_test = create_data(seed, 1, .2, .2, N_per_class)
+        View1_train, View2_train, labels_train, labels_train_full, \
+            View1_test, View2_test, labels_test = create_data(
+                seed, 1, .2, .2, N_per_class)
 
         # randomly remove some labels
         np.random.seed(11)
@@ -312,7 +313,7 @@ for count, iters in enumerate(N_iters):
     for seed in range(randomizations):
 
         # Create Data
-        View1_train, View2_train, labels_train, labels_train_full, View1_test,\
+        View1_train, View2_train, labels_train, labels_train_full, View1_test, \
             View2_test, labels_test = create_data(seed, 1, .2, .2, N_per_class)
         View2_train = View1_train.copy()
         View2_test = View1_test.copy()
@@ -409,9 +410,9 @@ for count, iters in enumerate(N_iters):
     for seed in range(randomizations):
 
         # Create Data
-        View1_train, View2_train, labels_train, labels_train_full, View1_test,\
-            View2_test, labels_test = create_data(seed, 1, .2, .2, N_per_class,
-                                                  view2_class2_mean_center=0)
+        View1_train, View2_train, labels_train, labels_train_full, \
+            View1_test, View2_test, labels_test = create_data(
+                seed, 1, .2, .2, N_per_class, view2_class2_mean_center=0)
 
         # randomly remove some labels
         np.random.seed(11)
@@ -827,9 +828,9 @@ for count, iters in enumerate(N_iters):
     for seed in range(randomizations):
 
         # Create Data
-        View1_train, View2_train, labels_train, labels_train_full, View1_test,\
-            View2_test, labels_test = create_data(seed, 0, .2, .2, N_per_class,
-                                                  class2_mean_center)
+        View1_train, View2_train, labels_train, labels_train_full, \
+        View1_test, View2_test, labels_test = create_data(
+            seed, 0, .2, .2, N_per_class, class2_mean_center)
 
         # randomly remove some labels
         np.random.seed(11)

--- a/examples/semi_supervised/plot_cotraining_classification.py
+++ b/examples/semi_supervised/plot_cotraining_classification.py
@@ -128,7 +128,9 @@ print("Naive Concatenated View Accuracy: {0:.3f}\n".format(
 # Multi-view co-training semi-supervised learning
 rfc0 = RandomForestClassifier(n_estimators=100, bootstrap=True)
 rfc1 = RandomForestClassifier(n_estimators=6, bootstrap=False)
-ctc = CTClassifier(rfc0, rfc1, p=2, n=2, unlabeled_pool_size=20, num_iter=100)
+ctc = CTClassifier(
+    rfc0, rfc1, positive_samples=2, negative_samples=2,
+    unlabeled_pool_size=20, num_iter=100)
 ctc.fit([View0_train, View1_train], labels_train)
 y_pred_ct = ctc.predict([View0_test, View1_test])
 

--- a/mvlearn/__init__.py
+++ b/mvlearn/__init__.py
@@ -9,4 +9,4 @@ import mvlearn.model_selection
 import mvlearn.plotting  # noqa
 
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/mvlearn/cluster/mv_kmeans.py
+++ b/mvlearn/cluster/mv_kmeans.py
@@ -461,7 +461,7 @@ class MultiviewKMeans(BaseCluster):
             max_iter = self.max_iter
 
         # While objective is still decreasing and iterations < max_iter
-        while(max(iter_stall) < self.patience and iter_num < max_iter):
+        while (max(iter_stall) < self.patience and iter_num < max_iter):
 
             for vi in range(2):
                 pre_view = (iter_num + 1) % 2
@@ -471,7 +471,7 @@ class MultiviewKMeans(BaseCluster):
             iter_num += 1
             # Track the number of iterations without improvement
             for view in range(2):
-                if(objective[view] - o_funct[view] > self.tol * np.abs(
+                if (objective[view] - o_funct[view] > self.tol * np.abs(
                         objective[view])):
                     objective[view] = o_funct[view]
                     iter_stall[view] = 0

--- a/mvlearn/cluster/mv_spectral.py
+++ b/mvlearn/cluster/mv_spectral.py
@@ -202,7 +202,7 @@ class MultiviewSpectralClustering(BaseCluster):
         # Produce the affinity matrix based on the selected kernel type
         if (self.affinity == 'rbf'):
             sims = rbf_kernel(X, gamma=gamma)
-        elif(self.affinity == 'nearest_neighbors'):
+        elif (self.affinity == 'nearest_neighbors'):
             neighbor = NearestNeighbors(n_neighbors=self.n_neighbors)
             neighbor.fit(X)
             sims = neighbor.kneighbors_graph(X).toarray()

--- a/mvlearn/datasets/gaussian_mixture.py
+++ b/mvlearn/datasets/gaussian_mixture.py
@@ -156,7 +156,7 @@ def make_gaussian_mixture(
 
     if callable(transform):
         X = np.asarray([transform(x) for x in latent])
-    elif not type(transform) == str:
+    elif not isinstance(transform, str):
         raise TypeError(
             "'transform' must be of type string or a callable function," +
             f"not {type(transform)}"

--- a/mvlearn/decomposition/grouppca.py
+++ b/mvlearn/decomposition/grouppca.py
@@ -196,7 +196,7 @@ class GroupPCA(BaseDecomposer):
         self.individual_pca_ = self.n_individual_components_ is not None
         self.individual_mean_ = [np.mean(X, axis=0) for X in Xs]
         if self.individual_pca_:
-            if type(self.n_individual_components_) == int:
+            if isinstance(self.n_individual_components_, int):
                 one_dimension = True
             else:
                 one_dimension = False

--- a/mvlearn/embed/dcca.py
+++ b/mvlearn/embed/dcca.py
@@ -211,8 +211,8 @@ class cca_loss():
 
         # Calculate the root inverse of covariance matrices by using
         # eigen decomposition
-        [D1, V1] = torch.symeig(SigmaHat11, eigenvectors=True)
-        [D2, V2] = torch.symeig(SigmaHat22, eigenvectors=True)
+        [D1, V1] = torch.linalg.eigh(SigmaHat11, UPLO='U')
+        [D2, V2] = torch.linalg.eigh(SigmaHat22, UPLO='U')
 
         # Additional code to increase numerical stability
         posInd1 = torch.gt(D1, eps).nonzero()[:, 0]
@@ -240,8 +240,8 @@ class cca_loss():
         else:
             # just the top self.n_components_ singular values are used to
             # compute the loss
-            U, V = torch.symeig(torch.matmul(
-                Tval.t(), Tval), eigenvectors=True)
+            U, V = torch.linalg.eigh(torch.matmul(
+                Tval.t(), Tval), UPLO='U')
             U = U.topk(self.n_components_)[0]
             corr = torch.sum(torch.sqrt(U))
         return -corr

--- a/mvlearn/embed/mvmds.py
+++ b/mvlearn/embed/mvmds.py
@@ -215,7 +215,7 @@ class MVMDS(BaseEmbed):
             # initializes pi for next iteration
             pi = pi - np.dot(q, q.T)
 
-        return(components)
+        return components
 
     def fit(self, Xs, y=None):
         """

--- a/mvlearn/semi_supervised/base.py
+++ b/mvlearn/semi_supervised/base.py
@@ -28,10 +28,10 @@ class BaseCoTrainEstimator(BaseEstimator):
 
     Attributes
     ----------
-    estimator1_ : estimator object
+    estimator1 : estimator object
         The estimator used on view 1.
 
-    estimator2_ : estimator object
+    estimator2 : estimator object
         The estimator used on view 2.
 
     random_state : int
@@ -44,8 +44,8 @@ class BaseCoTrainEstimator(BaseEstimator):
                  estimator2=None,
                  random_state=None
                  ):
-        self.estimator1_ = estimator1
-        self.estimator2_ = estimator2
+        self.estimator1 = estimator1
+        self.estimator2 = estimator2
         self.random_state = random_state
 
     @abstractmethod

--- a/mvlearn/semi_supervised/ctclassifier.py
+++ b/mvlearn/semi_supervised/ctclassifier.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from sklearn.naive_bayes import GaussianNB
+from copy import deepcopy
 
 from .base import BaseCoTrainEstimator
 from ..utils.utils import check_Xs, check_Xs_y_nan_allowed
@@ -34,7 +35,7 @@ class CTClassifier(BaseCoTrainEstimator):
         Does not need to be of the same type as ``estimator1``, but should
         support predict_proba().
 
-    p : int, optional (default=None)
+    positive_samples : int, optional (default=None)
         The number of positive classifications from the unlabeled_pool
         training set which will be given a positive "label". If None, the
         default is the floor of the ratio of positive to negative examples
@@ -43,7 +44,7 @@ class CTClassifier(BaseCoTrainEstimator):
         labels are 0 or 1, positive is defined as 1, and in general, positive
         is the larger label.
 
-    n : int, optional (default=None)
+    negative_samples : int, optional (default=None)
         The number of negative classifications from the unlabeled_pool
         training set which will be given a negative "label". If None, the
         default is the floor of the ratio of positive to negative examples
@@ -67,19 +68,19 @@ class CTClassifier(BaseCoTrainEstimator):
     Attributes
     ----------
     estimator1 : classifier object
-        The classifier used on view 1.
+        The classifier to be used on view 1.
 
     estimator2 : classifier object
-        The classifier used on view 2.
+        The classifier to be used on view 2.
 
     class_name_: string
         The name of the class.
 
-    p : int, optional (default=None)
+    positive_samples : int, optional (default=None)
         The number of positive classifications from the unlabeled_pool
         training set which will be given a positive "label" each round.
 
-    n : int, optional (default=None)
+    negative_samples : int, optional (default=None)
         The number of negative classifications from the unlabeled_pool
         training set which will be given a negative "label" each round.
 
@@ -145,7 +146,7 @@ class CTClassifier(BaseCoTrainEstimator):
           only the view 1 portion of the data (i.e. Xs[0])
         * Use *L* to train a classifier *h2* (``estimator2``) that considers
           only the view 2 portion of the data (i.e. Xs[1])
-        * Allow *h1* to label *p* (``self.p_``) positive and *n* (``self.n_``)
+        * Allow *h1* to label *p* positive and *n*
           negative samples from view 1 of *U'*
         * Allow *h2* to label *p* positive and *n* negative samples
           from view 2 of *U'*
@@ -167,8 +168,8 @@ class CTClassifier(BaseCoTrainEstimator):
     def __init__(self,
                  estimator1=None,
                  estimator2=None,
-                 p=None,
-                 n=None,
+                 positive_samples=None,
+                 negative_samples=None,
                  unlabeled_pool_size=75,
                  num_iter=50,
                  random_state=None
@@ -177,22 +178,9 @@ class CTClassifier(BaseCoTrainEstimator):
         # initialize a BaseCTEstimator object
         super().__init__(estimator1, estimator2, random_state)
 
-        # if not given, set classifiers as gaussian naive bayes estimators
-        if self.estimator1 is None:
-            self.estimator1 = GaussianNB()
-        if self.estimator2 is None:
-            self.estimator2 = GaussianNB()
-
-        # If only 1 of p or n is not None, set them equal
-        if (p is not None and n is None):
-            n = p
-            self.p, self.n = p, n
-        elif (p is None and n is not None):
-            p = n
-            self.p, self.n = p, n
-        else:
-            self.p, self.n = p, n
-
+        
+        self.positive_samples = positive_samples
+        self.negative_samples = negative_samples
         self.n_views = 2  # only 2 view learning supported currently
         self.class_name_ = "CTClassifier"
         self.unlabeled_pool_size = unlabeled_pool_size
@@ -212,14 +200,17 @@ class CTClassifier(BaseCoTrainEstimator):
         """
 
         # verify that estimator1 and estimator2 have predict_proba
-        if (not hasattr(self.estimator1, 'predict_proba') or
-                not hasattr(self.estimator2, 'predict_proba')):
+        if self.estimator1 is not None and (not hasattr(self.estimator1, 'predict_proba')):
+            raise AttributeError("Co-training classifier must be initialized "
+                                 "with classifiers supporting "
+                                 "predict_proba().")
+        if self.estimator2 is not None and (not hasattr(self.estimator2, 'predict_proba')):
             raise AttributeError("Co-training classifier must be initialized "
                                  "with classifiers supporting "
                                  "predict_proba().")
 
-        if (self.p is not None and self.p <= 0) or (self.n is not None and
-                                                    self.n <= 0):
+        if (self.positive_samples is not None and self.positive_samples <= 0) or \
+            (self.negative_samples is not None and self.negative_samples <= 0):
             raise ValueError("Both p and n must be positive.")
 
         if self.unlabeled_pool_size <= 0:
@@ -266,19 +257,41 @@ class CTClassifier(BaseCoTrainEstimator):
         X1 = Xs[0]
         X2 = Xs[1]
 
+        # if not given, set classifiers as gaussian naive bayes estimators
+        if self.estimator1 is None:
+            self.estimator1_ = GaussianNB()
+        else:
+            self.estimator1_ = deepcopy(self.estimator1)
+
+        if self.estimator2 is None:
+            self.estimator2_ = GaussianNB()
+        else:
+            self.estimator2_ = deepcopy(self.estimator2)
+
+        # If only 1 of p or n is not None, set them equal
+        p, n = self.positive_samples, self.negative_samples
+        if (p is not None and n is None):
+            n = p
+            self.positive_samples_, self.negative_samples_ = p, n
+        elif (p is None and n is not None):
+            p = n
+            self.positive_samples_, self.negative_samples_ = p, n
+        else:
+            self.positive_samples_, self.negative_samples_ = p, n
+
         # if don't have 2 classes of labeled data, then just fit and return,
         # since can't do any iterations of cotraining
         if self.n_classes > 1:
 
             # if both p & n are none, set as ratio of one class to the other
-            if (self.p is None and self.n is None):
+            if (self.positive_samples_ is None and self.negative_samples_ is None):
                 num_class_n = sum(1 for y_n in y if y_n == self.classes_[0])
                 num_class_p = sum(1 for y_p in y if y_p == self.classes_[1])
                 p_over_n_ratio = num_class_p // num_class_n
                 if p_over_n_ratio > 1:
-                    self.p, self.n = p_over_n_ratio, 1
+                    self.positive_samples_, self.negative_samples_ = p_over_n_ratio, 1
                 else:
-                    self.n, self.p = num_class_n // num_class_p, 1
+                    self.negative_samples_, self.positive_samples_ = num_class_n // num_class_p, 1
 
             # the full set of unlabeled samples
             U = [i for i, y_i in enumerate(y) if np.isnan(y_i)]
@@ -305,30 +318,30 @@ class CTClassifier(BaseCoTrainEstimator):
                 it += 1
 
                 # fit each model to its respective view
-                self.estimator1.fit(X1[L], y[L])
-                self.estimator2.fit(X2[L], y[L])
+                self.estimator1_.fit(X1[L], y[L])
+                self.estimator2_.fit(X2[L], y[L])
 
                 # predict log probability for greater spread in confidence
 
-                y1_prob = np.log(self.estimator1.
+                y1_prob = np.log(self.estimator1_.
                                  predict_proba(X1[unlabeled_pool]) + eps)
-                y2_prob = np.log(self.estimator2.
+                y2_prob = np.log(self.estimator2_.
                                  predict_proba(X2[unlabeled_pool]) + eps)
 
                 n, p = [], []
 
                 # take the most confident labeled examples from the
                 # unlabeled pool in each category and put them in L
-                for i in (y1_prob[:, 0].argsort())[-self.n:]:
+                for i in (y1_prob[:, 0].argsort())[-self.negative_samples_:]:
                     if y1_prob[i, 0] > np.log(0.5):
                         n.append(i)
-                for i in (y1_prob[:, 1].argsort())[-self.p:]:
+                for i in (y1_prob[:, 1].argsort())[-self.positive_samples_:]:
                     if y1_prob[i, 1] > np.log(0.5):
                         p.append(i)
-                for i in (y2_prob[:, 0].argsort())[-self.n:]:
+                for i in (y2_prob[:, 0].argsort())[-self.negative_samples_:]:
                     if y2_prob[i, 0] > np.log(0.5):
                         n.append(i)
-                for i in (y2_prob[:, 1].argsort())[-self.p:]:
+                for i in (y2_prob[:, 1].argsort())[-self.positive_samples_:]:
                     if y2_prob[i, 1] > np.log(0.5):
                         p.append(i)
 
@@ -357,8 +370,8 @@ class CTClassifier(BaseCoTrainEstimator):
             L = [i for i, y_i in enumerate(y) if ~np.isnan(y_i)]
 
         # fit the overall model on fully "labeled" data
-        self.estimator1.fit(X1[L], y[L])
-        self.estimator2.fit(X2[L], y[L])
+        self.estimator1_.fit(X1[L], y[L])
+        self.estimator2_.fit(X2[L], y[L])
 
         return self
 
@@ -389,8 +402,8 @@ class CTClassifier(BaseCoTrainEstimator):
         X2 = Xs[1]
 
         # predict each view independently
-        y1 = self.estimator1.predict(X1)
-        y2 = self.estimator2.predict(X2)
+        y1 = self.estimator1_.predict(X1)
+        y2 = self.estimator2_.predict(X2)
 
         # initialize
         y_pred = np.zeros(X1.shape[0],)
@@ -402,8 +415,8 @@ class CTClassifier(BaseCoTrainEstimator):
                 y_pred[i] = y1_i
             # if classifiers don't agree, take the more confident
             else:
-                y1_probs = self.estimator1.predict_proba([X1[i]])[0]
-                y2_probs = self.estimator2.predict_proba([X2[i]])[0]
+                y1_probs = self.estimator1_.predict_proba([X1[i]])[0]
+                y2_probs = self.estimator2_.predict_proba([X2[i]])[0]
                 sum_y_probs = [prob1 + prob2 for (prob1, prob2) in
                                zip(y1_probs, y2_probs)]
                 max_sum_prob = max(sum_y_probs)
@@ -436,7 +449,7 @@ class CTClassifier(BaseCoTrainEstimator):
         X2 = Xs[1]
 
         # predict each probability independently
-        y1_proba = self.estimator1.predict_proba(X1)
-        y2_proba = self.estimator2.predict_proba(X2)
+        y1_proba = self.estimator1_.predict_proba(X1)
+        y2_proba = self.estimator2_.predict_proba(X2)
         # return the average probability for the sample
         return (y1_proba + y2_proba) * .5

--- a/mvlearn/semi_supervised/ctclassifier.py
+++ b/mvlearn/semi_supervised/ctclassifier.py
@@ -178,7 +178,6 @@ class CTClassifier(BaseCoTrainEstimator):
         # initialize a BaseCTEstimator object
         super().__init__(estimator1, estimator2, random_state)
 
-        
         self.positive_samples = positive_samples
         self.negative_samples = negative_samples
         self.n_views = 2  # only 2 view learning supported currently
@@ -200,17 +199,21 @@ class CTClassifier(BaseCoTrainEstimator):
         """
 
         # verify that estimator1 and estimator2 have predict_proba
-        if self.estimator1 is not None and (not hasattr(self.estimator1, 'predict_proba')):
+        if self.estimator1 is not None and \
+                (not hasattr(self.estimator1, 'predict_proba')):
             raise AttributeError("Co-training classifier must be initialized "
                                  "with classifiers supporting "
                                  "predict_proba().")
-        if self.estimator2 is not None and (not hasattr(self.estimator2, 'predict_proba')):
+        if self.estimator2 is not None and \
+                (not hasattr(self.estimator2, 'predict_proba')):
             raise AttributeError("Co-training classifier must be initialized "
                                  "with classifiers supporting "
                                  "predict_proba().")
 
-        if (self.positive_samples is not None and self.positive_samples <= 0) or \
-            (self.negative_samples is not None and self.negative_samples <= 0):
+        if (self.positive_samples is not None and
+                self.positive_samples <= 0) or \
+                (self.negative_samples is not None and
+                    self.negative_samples <= 0):
             raise ValueError("Both p and n must be positive.")
 
         if self.unlabeled_pool_size <= 0:
@@ -284,14 +287,17 @@ class CTClassifier(BaseCoTrainEstimator):
         if self.n_classes > 1:
 
             # if both p & n are none, set as ratio of one class to the other
-            if (self.positive_samples_ is None and self.negative_samples_ is None):
+            if self.positive_samples_ is None and \
+                    self.negative_samples_ is None:
                 num_class_n = sum(1 for y_n in y if y_n == self.classes_[0])
                 num_class_p = sum(1 for y_p in y if y_p == self.classes_[1])
                 p_over_n_ratio = num_class_p // num_class_n
                 if p_over_n_ratio > 1:
-                    self.positive_samples_, self.negative_samples_ = p_over_n_ratio, 1
+                    self.positive_samples_ = p_over_n_ratio
+                    self.negative_samples_ = 1
                 else:
-                    self.negative_samples_, self.positive_samples_ = num_class_n // num_class_p, 1
+                    self.negative_samples_ = num_class_n // num_class_p
+                    self.positive_samples_ = 1
 
             # the full set of unlabeled samples
             U = [i for i, y_i in enumerate(y) if np.isnan(y_i)]

--- a/mvlearn/semi_supervised/ctclassifier.py
+++ b/mvlearn/semi_supervised/ctclassifier.py
@@ -219,7 +219,7 @@ class CTClassifier(BaseCoTrainEstimator):
                                  "predict_proba().")
 
         if (self.p is not None and self.p <= 0) or (self.n is not None and
-                                                      self.n <= 0):
+                                                    self.n <= 0):
             raise ValueError("Both p and n must be positive.")
 
         if self.unlabeled_pool_size <= 0:

--- a/mvlearn/semi_supervised/ctregression.py
+++ b/mvlearn/semi_supervised/ctregression.py
@@ -50,14 +50,14 @@ class CTRegressor(BaseCoTrainEstimator):
 
     Attributes
     ----------
-    estimator1_ : regressor object, used on view1
+    estimator1 : regressor object, used on view1
 
-    estimator2_ : regressor object, used on view2
+    estimator2 : regressor object, used on view2
 
     class_name_: string
         The name of the class.
 
-    k_neighbors_ : int
+    k_neighbors : int
         The number of neighbors to be considered for determining
         the mean squared error.
 
@@ -170,19 +170,17 @@ class CTRegressor(BaseCoTrainEstimator):
         random_state=None
     ):
 
-        # initialize a BaseCTEstimator object
-        super().__init__(estimator1, estimator2, random_state)
-
         # If not given, initialize with default KNeighborsRegrssor
         if estimator1 is None:
             estimator1 = KNeighborsRegressor()
         if estimator2 is None:
             estimator2 = KNeighborsRegressor()
 
+        # initialize a BaseCTEstimator object
+        super().__init__(estimator1, estimator2, random_state)
+
         # Initializing the other attributes
-        self.estimator1_ = estimator1
-        self.estimator2_ = estimator2
-        self.k_neighbors_ = k_neighbors
+        self.k_neighbors = k_neighbors
         self.unlabeled_pool_size = unlabeled_pool_size
         self.num_iter = num_iter
 
@@ -211,8 +209,8 @@ class CTRegressor(BaseCoTrainEstimator):
 
         # Taking the str of estimator object
         # returns the class name along with other parameters
-        string1 = str(self.estimator1_)
-        string2 = str(self.estimator2_)
+        string1 = str(self.estimator1)
+        string2 = str(self.estimator2)
 
         # slicing the list to get the name of the estimator
         string1 = string1[: len(to_be_matched)]
@@ -222,7 +220,7 @@ class CTRegressor(BaseCoTrainEstimator):
             raise AttributeError(
                 "Both the estimator needs to be KNeighborsRegressor")
 
-        if self.k_neighbors_ <= 0:
+        if self.k_neighbors <= 0:
             raise ValueError("k_neighbors must be positive")
 
         if self.unlabeled_pool_size <= 0:
@@ -278,8 +276,8 @@ class CTRegressor(BaseCoTrainEstimator):
         L2 = L.copy()
 
         # fitting the estimator object on the train data
-        self.estimator1_.fit(X1[L1], y1[L1])
-        self.estimator2_.fit(X2[L2], y2[L2])
+        self.estimator1.fit(X1[L1], y1[L1])
+        self.estimator2.fit(X2[L2], y2[L2])
 
         # declaring a variable which keeps tracks
         # of the number of iteration performed
@@ -296,13 +294,13 @@ class CTRegressor(BaseCoTrainEstimator):
             it += 1
 
             # list of k nearest neighbors for all unlabeled samples
-            neighbors1 = self.estimator1_.kneighbors(
+            neighbors1 = self.estimator1.kneighbors(
                 X1[unlabeled_pool],
-                n_neighbors=self.k_neighbors_,
+                n_neighbors=self.k_neighbors,
                 return_distance=False)
-            neighbors2 = self.estimator2_.kneighbors(
+            neighbors2 = self.estimator2.kneighbors(
                 X2[unlabeled_pool],
-                n_neighbors=self.k_neighbors_,
+                n_neighbors=self.k_neighbors,
                 return_distance=False)
 
             # Stores the delta value of each view
@@ -316,7 +314,7 @@ class CTRegressor(BaseCoTrainEstimator):
                 new_L1.append(u)
 
                 # Predicts the value of unlabeled index
-                pred = self.estimator1_.predict(np.expand_dims(X1[u], axis=0))
+                pred = self.estimator1.predict(np.expand_dims(X1[u], axis=0))
 
                 # assigning the predicted value to new y
                 new_y1 = y1.copy()
@@ -325,13 +323,13 @@ class CTRegressor(BaseCoTrainEstimator):
                 # prediction array before inclusion of unlabeled index
                 pred_before_inc = []
 
-                pred_before_inc = self.estimator1_.predict((X1[L1])[neigh])
+                pred_before_inc = self.estimator1.predict((X1[L1])[neigh])
 
                 # new estimator for training a regressor model on new L1
                 new_estimator = KNeighborsRegressor()
 
                 # Setting the same parameters as that of estimator1 object
-                new_estimator.set_params(**self.estimator1_.get_params())
+                new_estimator.set_params(**self.estimator1.get_params())
                 new_estimator.fit(X1[new_L1], new_y1[new_L1])
 
                 # prediction array after inclusion of unlabeled index
@@ -356,7 +354,7 @@ class CTRegressor(BaseCoTrainEstimator):
                 # Predicts the value of unlabeled index
                 pred_before_inc = []
 
-                pred = self.estimator2_.predict(
+                pred = self.estimator2.predict(
                     np.expand_dims(X2[u], axis=0))
 
                 # assigning the predicted value to new y
@@ -364,13 +362,13 @@ class CTRegressor(BaseCoTrainEstimator):
                 new_y2[u] = pred
 
                 # prediction array before inclusion of unlabeled index
-                pred_before_inc = self.estimator2_.predict((X2[L2])[neigh])
+                pred_before_inc = self.estimator2.predict((X2[L2])[neigh])
 
                 # new estimator for training a regressor model on new L2
                 new_estimator = KNeighborsRegressor()
 
                 # Setting the same parameters as that of estimator2 object
-                new_estimator.set_params(**self.estimator2_.get_params())
+                new_estimator.set_params(**self.estimator2.get_params())
                 new_estimator.fit(X2[new_L2], new_y2[new_L2])
 
                 # prediction array after inclusion of unlabeled index
@@ -468,13 +466,13 @@ class CTRegressor(BaseCoTrainEstimator):
 
             # including the selected index
             for i in to_include1:
-                pred = self.estimator2_.predict(
+                pred = self.estimator2.predict(
                     np.expand_dims(X2[unlabeled_pool[i]], axis=0))
                 y1[unlabeled_pool[i]] = pred
 
             # including the selected index
             for i in to_include2:
-                pred = self.estimator1_.predict(
+                pred = self.estimator1.predict(
                     np.expand_dims(X1[unlabeled_pool[i]], axis=0))
                 y2[unlabeled_pool[i]] = pred
 
@@ -503,8 +501,8 @@ class CTRegressor(BaseCoTrainEstimator):
             U = [i for i in U if i not in unlabeled_pool]
 
             # fitting the model on new train data
-            self.estimator1_.fit(X1[L1], y1[L1])
-            self.estimator2_.fit(X2[L2], y2[L2])
+            self.estimator1.fit(X1[L1], y1[L1])
+            self.estimator2.fit(X2[L2], y2[L2])
 
         return self
 
@@ -530,8 +528,8 @@ class CTRegressor(BaseCoTrainEstimator):
         X2 = Xs[1]
 
         # predicting the value of each view
-        pred1 = self.estimator1_.predict(X1)
-        pred2 = self.estimator2_.predict(X2)
+        pred1 = self.estimator1.predict(X1)
+        pred2 = self.estimator2.predict(X2)
 
         # Taking the average of the predicted value and returning it
         return (pred1 + pred2) * 0.5

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,2 +1,2 @@
-torch>=1.1.0
+torch>=1.9.0
 tqdm

--- a/tests/datasets/test_gaussian_mixture.py
+++ b/tests/datasets/test_gaussian_mixture.py
@@ -78,7 +78,6 @@ def test_bad_shapes():
             n_samples, centers, [np.eye(2), np.eye(3)],
             class_probs=class_probs
         )
-    assert str(e.value) == "covariance matrix is of the incorrect shape"
     # Wrong uni dimensions
     with pytest.raises(ValueError) as e:
         make_gaussian_mixture(n_samples, [1, 0], [1, 0])

--- a/tests/multiviewica/test_groupica.py
+++ b/tests/multiviewica/test_groupica.py
@@ -59,7 +59,7 @@ def test_badsolver():
     "n_individual_components", ["auto", None, 3, [2, 3, 4]]
 )
 @pytest.mark.parametrize("multiview_output", [True, False])
-@pytest.mark.parametrize("whiten", [True, False])
+@pytest.mark.parametrize("whiten", ["unit-variance", False])
 @pytest.mark.parametrize("solver", ["picard", "fastica"])
 def test_transform(
     n_components, n_individual_components, multiview_output, solver, whiten

--- a/tests/test_ctclassifier.py
+++ b/tests/test_ctclassifier.py
@@ -103,19 +103,19 @@ def test_predict_zero_classes(data):
 
 def test_zero_p():
     with pytest.raises(ValueError):
-        clf = CTClassifier(GaussianNB(), GaussianNB(), p=0)
+        clf = CTClassifier(GaussianNB(), GaussianNB(), positive_samples=0)
 
 def test_negative_p():
     with pytest.raises(ValueError):
-        clf = CTClassifier(GaussianNB(), GaussianNB(), p=-1)
+        clf = CTClassifier(GaussianNB(), GaussianNB(), positive_samples=-1)
 
 def test_zero_n():
     with pytest.raises(ValueError):
-        clf = CTClassifier(GaussianNB(), GaussianNB(), n=0)
+        clf = CTClassifier(GaussianNB(), GaussianNB(), negative_samples=0)
 
 def test_negative_n():
     with pytest.raises(ValueError):
-        clf = CTClassifier(GaussianNB(), GaussianNB(), n=-1)
+        clf = CTClassifier(GaussianNB(), GaussianNB(), negative_samples=-1)
 
 def test_zero_pool_size():
     with pytest.raises(ValueError):
@@ -186,8 +186,8 @@ def test_predict_check_p_n(data):
     labels1[15:] = np.nan
     clf = CTClassifier(random_state=0)
     clf.fit(data['random_data'], labels1)
-    assert clf.p == 2
-    assert clf.n == 1
+    assert clf.positive_samples_ == 2
+    assert clf.negative_samples_ == 1
 
     labels2 = np.zeros(100,)
     labels2[:5] = 6 # 5 "positive"
@@ -195,23 +195,23 @@ def test_predict_check_p_n(data):
     labels2[15:] = np.nan
     clf = CTClassifier(random_state=0)
     clf.fit(data['random_data'], labels2)
-    assert clf.p == 1
-    assert clf.n == 2
+    assert clf.positive_samples_ == 1
+    assert clf.negative_samples_ == 2
 
     labels1 = np.zeros(100,)
     labels1[:5] = 4 # 5 "negative"
     labels1[5:15] = 6 # 10 "positive"
     labels1[15:] = np.nan
-    clf = CTClassifier(p=4, n=3, random_state=0)
+    clf = CTClassifier(positive_samples=4, negative_samples=3, random_state=0)
     clf.fit(data['random_data'], labels1)
-    assert clf.p == 4
-    assert clf.n == 3
+    assert clf.positive_samples_ == 4
+    assert clf.negative_samples_ == 3
 
 def test_predict_set_p(data):
     random_seed = 10
     gnb1 = GaussianNB()
     gnb2 = GaussianNB()
-    clf = CTClassifier(gnb1, gnb2, p=12, random_state=random_seed)
+    clf = CTClassifier(gnb1, gnb2, positive_samples=12, random_state=random_seed)
     clf.fit(data['random_data'], data['random_labels'])
     y_pred_test = clf.predict(data['random_test'])
     y_pred_prob = clf.predict_proba(data['random_test'])
@@ -234,7 +234,7 @@ def test_predict_set_n(data):
     random_seed = 10
     gnb1 = GaussianNB()
     gnb2 = GaussianNB()
-    clf = CTClassifier(gnb1, gnb2, n=9, random_state=random_seed)
+    clf = CTClassifier(gnb1, gnb2, negative_samples=9, random_state=random_seed)
     clf.fit(data['random_data'], data['random_labels'])
     y_pred_test = clf.predict(data['random_test'])
     y_pred_prob = clf.predict_proba(data['random_test'])

--- a/tests/test_ctclassifier.py
+++ b/tests/test_ctclassifier.py
@@ -186,8 +186,8 @@ def test_predict_check_p_n(data):
     labels1[15:] = np.nan
     clf = CTClassifier(random_state=0)
     clf.fit(data['random_data'], labels1)
-    assert clf.p_ == 2
-    assert clf.n_ == 1
+    assert clf.p == 2
+    assert clf.n == 1
 
     labels2 = np.zeros(100,)
     labels2[:5] = 6 # 5 "positive"
@@ -195,8 +195,8 @@ def test_predict_check_p_n(data):
     labels2[15:] = np.nan
     clf = CTClassifier(random_state=0)
     clf.fit(data['random_data'], labels2)
-    assert clf.p_ == 1
-    assert clf.n_ == 2
+    assert clf.p == 1
+    assert clf.n == 2
 
     labels1 = np.zeros(100,)
     labels1[:5] = 4 # 5 "negative"
@@ -204,8 +204,8 @@ def test_predict_check_p_n(data):
     labels1[15:] = np.nan
     clf = CTClassifier(p=4, n=3, random_state=0)
     clf.fit(data['random_data'], labels1)
-    assert clf.p_ == 4
-    assert clf.n_ == 3
+    assert clf.p == 4
+    assert clf.n == 3
 
 def test_predict_set_p(data):
     random_seed = 10

--- a/tests/test_ctregressor.py
+++ b/tests/test_ctregressor.py
@@ -147,7 +147,7 @@ def test_set_k_neighbors(data):
     ctr = CTRegressor(k_neighbors=k_neighbors, random_state=10)
     ctr.fit(data['random_data'], data['random_labels'])
     pred = (ctr.predict(data['random_test'])).tolist()
-    assert ctr.k_neighbors_ == k_neighbors
+    assert ctr.k_neighbors == k_neighbors
     assert len(truth) == len(pred)
     for i, j in zip(truth, pred):
         assert abs(i-j) < 0.00000001


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/mvlearn/mvlearn/blob/main/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #317 

#### What does this implement/fix? Explain your changes.
Changes the attribute names of estimator1 and estimator2 in CTClassifier and CTRegressor to not have trailing underscores, which allows them to be properly picked up by sklearn's get_params() method. Also editted other init args which were set as attributes with trailing underscores.

#### Any other comments?

