### PR TITLE
Fix call to pytest.warns to be compatible with pytest 8.0

### DIFF
--- a/tests/embed/test_mcca.py
+++ b/tests/embed/test_mcca.py
@@ -240,7 +240,7 @@ def test_mcca_n_components():
     mcca = MCCA(n_components=n_features+1)
     with pytest.raises(AttributeError):
         mcca.n_components_
-    with pytest.warns(None):
+    with pytest.warns():
         mcca.fit(Xs)
     assert mcca.n_components_ == n_features
     for load in mcca.loadings_:
@@ -253,7 +253,7 @@ def test_kmcca_n_components():
     kmcca = KMCCA(n_components=n_features+1)
     with pytest.raises(AttributeError):
         kmcca.n_components_
-    with pytest.warns(None):
+    with pytest.warns():
         kmcca.fit(Xs)
     assert kmcca.n_components_ == n_features
     for load in kmcca.dual_vars_:


### PR DESCRIPTION
`pytest.warns(None)` fails with pytest version 8.0: https://docs.pytest.org/en/stable/deprecations.html#using-pytest-warns-none

```
$ pytest tests/embed/test_mcca.py 
===================================================================== test session starts =====================================================================
platform linux -- Python 3.11.2, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/amauryfa/dev/mvlearn
configfile: pytest.ini
plugins: cov-6.0.0
collected 981 items                                                                                                                                           
=================================================================== short test summary info ===================================================================
FAILED tests/embed/test_mcca.py::test_mcca_n_components - TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
FAILED tests/embed/test_mcca.py::test_kmcca_n_components - TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
=============================================================== 2 failed, 979 passed in 35.28s ================================================================
```
